### PR TITLE
Update ultralcd.cpp

### DIFF
--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3023,9 +3023,9 @@ static void lcd_menu_xyz_offset()
 
     for (uint_least8_t i = 0; i < 2; i++)
     {
-        lcd_puts_at_P(11, i + 2, PSTR(""));
+        lcd_puts_at_P((cntr[i] < 0) ? 10 : 11, i + 2, PSTR(""));
         lcd_print(cntr[i]);
-        lcd_puts_at_P((cntr[i] < 0) ? 17 : 16, i + 2, PSTR("mm"));
+        lcd_puts_at_P(16, i + 2, PSTR("mm"));
     }
     menu_back_if_clicked();
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3023,7 +3023,7 @@ static void lcd_menu_xyz_offset()
 
     for (uint_least8_t i = 0; i < 2; i++)
     {
-        lcd_puts_at_P((cntr[i] < 0) ? 10 : 11, i + 2, PSTR(""));
+        lcd_set_cursor((cntr[i] < 0) ? 10 : 11, i+2);
         lcd_print(cntr[i]);
         lcd_puts_at_P(16, i + 2, PSTR("mm"));
     }


### PR DESCRIPTION
Menu Support -> XYZ calibration details -> 3. obrazovka "point offset"
X and Y value are no longer moved to the left if there’s no negative sign