### PR TITLE
PFW-1312 Define layout of LCD for MMU error screens

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -645,12 +645,11 @@ void crashdet_detected(uint8_t mask)
         lcd_puts_P(_T(MSG_RESUME_PRINT));
         lcd_putc('?');
         bool yesno = lcd_show_yes_no_and_wait(false);
-		lcd_update_enable(true);
-		if (yesno)
+		if (yesno == LEFT_BUTTON_CHOICE)
 		{
 			enquecommand_P(PSTR("CRASH_RECOVER"));
 		}
-		else
+		else // MIDDLE_BUTTON_CHOICE
 		{
 			enquecommand_P(PSTR("CRASH_CANCEL"));
 		}
@@ -1643,7 +1642,7 @@ void setup()
 #ifdef UVLO_SUPPORT
   if (eeprom_read_byte((uint8_t*)EEPROM_UVLO) != 0) { //previous print was terminated by UVLO
 /*
-	  if (lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false))	recover_print();
+	  if (!lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false))	recover_print();
 	  else {
 		  eeprom_update_byte((uint8_t*)EEPROM_UVLO, 0);
 		  lcd_update_enable(true);
@@ -1665,8 +1664,9 @@ void setup()
           #ifdef DEBUG_UVLO_AUTOMATIC_RECOVER 
         puts_P(_N("Normal recovery!")); 
           #endif 
-          if ( lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false) ) recover_print(0); 
-          else { 
+          if ( lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_RECOVER_PRINT), false) == LEFT_BUTTON_CHOICE) {
+              recover_print(0); 
+          } else { 
               eeprom_update_byte((uint8_t*)EEPROM_UVLO, 0); 
               lcd_update_enable(true); 
               lcd_update(2); 
@@ -3507,9 +3507,11 @@ bool gcode_M45(bool onlyZ, int8_t verbosity_level)
 			KEEPALIVE_STATE(PAUSED_FOR_USER);
 			#ifdef STEEL_SHEET
 			bool result = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false, false);
-			if(result) lcd_show_fullscreen_message_and_wait_P(_T(MSG_REMOVE_STEEL_SHEET));
+			if(result == LEFT_BUTTON_CHOICE) {
+				lcd_show_fullscreen_message_and_wait_P(_T(MSG_REMOVE_STEEL_SHEET));
+			}
 			#endif //STEEL_SHEET
-		    lcd_show_fullscreen_message_and_wait_P(_T(MSG_PAPER));
+			lcd_show_fullscreen_message_and_wait_P(_T(MSG_PAPER));
 			KEEPALIVE_STATE(IN_HANDLER);
 			lcd_display_message_fullscreen_P(_T(MSG_FIND_BED_OFFSET_AND_SKEW_LINE1));
 			lcd_puts_at_P(0,3,_n("1/4"));
@@ -3803,7 +3805,7 @@ static void gcode_M600(bool automatic, float x_position, float y_position, float
         KEEPALIVE_STATE(PAUSED_FOR_USER);
         lcd_change_fil_state =
             lcd_show_fullscreen_message_yes_no_and_wait_P(_i("Was filament unload successful?"), false, true); ////MSG_UNLOAD_SUCCESSFUL c=20 r=2
-        if (lcd_change_fil_state == 0) {
+        if (lcd_change_fil_state == MIDDLE_BUTTON_CHOICE) {
             lcd_clear();
             lcd_puts_at_P(0, 2, _T(MSG_PLEASE_WAIT));
             current_position[X_AXIS] -= 100;
@@ -5174,7 +5176,7 @@ eeprom_update_word((uint16_t*)EEPROM_NOZZLE_DIAMETER_uM,0xFFFF);
         lcd_show_fullscreen_message_and_wait_P(_i("Stable ambient temperature 21-26C is needed a rigid stand is required."));////MSG_TEMP_CAL_WARNING c=20 r=4
         bool result = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false, false);
 
-        if (result)
+        if (result == LEFT_BUTTON_CHOICE)
         {
             current_position[Z_AXIS] = MESH_HOME_Z_SEARCH;
             plan_buffer_line_curposXYZE(3000 / 60);

--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -129,30 +129,6 @@ extern void lcd_update_enable(uint8_t enabled);
 
 extern void lcd_buttons_update(void);
 
-//! @brief Helper class to temporarily disable LCD updates
-//!
-//! When constructed (on stack), original state state of lcd_update_enabled is stored
-//! and LCD updates are disabled.
-//! When destroyed (gone out of scope), original state of LCD update is restored.
-//! It has zero overhead compared to storing bool saved = lcd_update_enabled
-//! and calling lcd_update_enable(false) and lcd_update_enable(saved).
-class LcdUpdateDisabler
-{
-public:
-    LcdUpdateDisabler(): m_updateEnabled(lcd_update_enabled)
-    {
-        lcd_update_enable(false);
-    }
-    ~LcdUpdateDisabler()
-    {
-        lcd_update_enable(m_updateEnabled);
-    }
-
-private:
-    bool m_updateEnabled;
-};
-
-
 ////////////////////////////////////
 // Setup button and encode mappings for each panel (into 'lcd_buttons' variable
 //

--- a/Firmware/menu.cpp
+++ b/Firmware/menu.cpp
@@ -384,9 +384,7 @@ uint8_t menu_item_function_P(const char* str, char number, void (*func)(uint8_t)
         {
             menu_clicked = false;
             lcd_consume_click();
-            lcd_update_enabled = 0;
             if (func) func(fn_par);
-            lcd_update_enabled = 1;
             return menu_item_ret();
         }
     }

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -512,8 +512,8 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         // - failed -> then do the safety moves on the printer like before
         // - finished ok -> proceed with reading other commands
         manage_heater();
-        // @@TODO this needs verification - we need something which matches Marlin2's idle()
         manage_inactivity(true); // calls LogicStep() and remembers its return status
+        lcd_update(0);
 
         switch (logicStepLastStatus) {
         case Finished: 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -607,22 +607,8 @@ void MMU2::ReportError(ErrorCode ec) {
 
     if( ec != lastErrorCode ){ // deduplicate: only report changes in error codes into the log
         lastErrorCode = ec;
-
-        // Log error format: MMU2:E=32766 ErrorTitle TextDescription
-
-        // The longest error description in errors_list.h is 144 bytes.
-        // and the longest error title is 20 bytes. msg buffer needs
-        // to have enough space to fit both.
-        char msg[192];
-        int len = snprintf(msg, sizeof(msg), "MMU2:E=%hu ", (uint16_t)ec);
-        // Append a human readable form of the error code(s)
-        TranslateErr((uint16_t)ec, &msg[len], 192 - len);
-
-        // beware - the prefix in the message ("MMU2") will get stripped by the logging subsystem
-        // and a correct MMU2 component will be assigned accordingly - see appmain.cpp
-        // Therefore I'm not calling MMU2_ERROR_MSG or MMU2_ECHO_MSG here
         SERIAL_ECHO_START;
-        SERIAL_ECHOLN(msg);
+        SERIAL_ECHOLNRPGM( PrusaErrorTitle(PrusaErrorCodeIndex((uint16_t)ec)) );
     }
 
     static_assert(mmu2Magic[0] == 'M' 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -1,7 +1,5 @@
 #include "mmu2.h"
 #include "mmu2_error_converter.h"
-#include "mmu2/error_codes.h"
-#include "mmu2/errors_list.h"
 #include "mmu2_fsensor.h"
 #include "mmu2_log.h"
 #include "mmu2_power.h"

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -615,56 +615,16 @@ void MMU2::ReportError(ErrorCode ec) {
         // The longest error description in errors_list.h is 144 bytes.
         // and the longest error title is 20 bytes. msg buffer needs
         // to have enough space to fit both.
-        //char msg[192];
-        //int len = snprintf(msg, sizeof(msg), "MMU2:E=%hu ", (uint16_t)ec);
+        char msg[192];
+        int len = snprintf(msg, sizeof(msg), "MMU2:E=%hu ", (uint16_t)ec);
         // Append a human readable form of the error code(s)
-        //TranslateErr((uint16_t)ec, &msg[len], 192 - len);
-
-        const uint16_t ei = MMUErrorCodeIndex((uint16_t)ec);
-          // Testing
-        uint8_t choice_selected = 0;
-        back_to_choices:
-        // 504 = ERR_SYSTEM_VERSION_MISMATCH
-        lcd_clear();
-        lcd_update_enable(false);
-        lcd_printf_P(PSTR("%S\nprusa3d.com/ERR04%hu"),
-            static_cast<const char * const>(pgm_read_ptr(&errorTitles[ei])),
-            reinterpret_cast<uint16_t>(const_cast<void*>(pgm_read_ptr(&errorCodes[ei])))
-        );
-        choice_selected = lcd_show_multiscreen_message_two_choices_and_wait_P(
-            NULL, // NULL, since title screen is not in PROGMEM
-            false,
-            false,
-            btnRetry,
-            btnContinue,
-            btnMore,
-            7,
-            13
-        );
-
-        if (choice_selected == 2) {
-            // 'More' show error description
-            lcd_show_fullscreen_message_and_wait_P(
-                static_cast<const char * const>(pgm_read_ptr(&errorDescs[ei]))
-            );
-
-            // Return back to the choice menu
-            goto back_to_choices;
-        } else if(choice_selected == 1) {
-            // 'Done' return to status screen
-            lcd_update_enable(true);
-            lcd_return_to_status();
-        } else {
-            // 'Retry' TODO: not yet implemented
-            lcd_update_enable(true);
-            lcd_return_to_status();
-        }
+        TranslateErr((uint16_t)ec, &msg[len], 192 - len);
 
         // beware - the prefix in the message ("MMU2") will get stripped by the logging subsystem
         // and a correct MMU2 component will be assigned accordingly - see appmain.cpp
         // Therefore I'm not calling MMU2_ERROR_MSG or MMU2_ECHO_MSG here
-        //SERIAL_ECHO_START;
-        //SERIAL_ECHOLN(msg);
+        SERIAL_ECHO_START;
+        SERIAL_ECHOLN(msg);
     }
 
     static_assert(mmu2Magic[0] == 'M' 

--- a/Firmware/mmu2/buttons.h
+++ b/Firmware/mmu2/buttons.h
@@ -1,0 +1,22 @@
+#pragma once
+#include <stdint.h>
+
+// Helper macros to parse the operations from Btns()
+#define BUTTON_OP_HI_NIBBLE(X) ( ( X & 0xF0 ) >> 4 )
+#define BUTTON_OP_LO_NIBBLE(X) ( X & 0x0F )
+
+namespace MMU2 {
+
+/// Will be mapped onto dialog button responses in the FW
+/// Those responses have their unique+translated texts as well
+enum class ButtonOperations : uint8_t {
+    NoOperation = 0,
+    Retry       = 1,
+    Continue    = 2,
+    RestartMMU  = 3,
+    Unload      = 4,
+    StopPrint   = 5,
+    DisableMMU  = 6,
+};
+
+} // namespace MMU2

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -243,8 +243,6 @@ static const char * const errorDescs[] PROGMEM = {
     descRUNTIME_ERROR,
 };
 
-#define BUTTON_OP_HIGH_NIBBLE_MSK 0xF0
-#define BUTTON_OP_LOW_NIBBLE_MSK  0x0F
 
 /// Will be mapped onto dialog button responses in the FW
 /// Those responses have their unique+translated texts as well
@@ -284,6 +282,10 @@ static const char * const btnOperation[] PROGMEM = {
     btnStop,
     btnDisableMMU
 };
+
+// Helper macros to parse the operations from Btns()
+#define BUTTON_OP_HI_NIBBLE(X) ( ( X & 0xF0 ) >> 4 )
+#define BUTTON_OP_LO_NIBBLE(X) ( X & 0x0F )
 
 // We have 8 different operations/buttons at this time, so we need at least 4 bits to encode each.
 // Since one of the buttons is always "More", we can skip that one.

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -269,7 +269,7 @@ static const char btnRestartMMU[] PROGMEM_I1 = ISTR("RstMMU");
 static const char btnUnload[] PROGMEM_I1 = ISTR("Unload");
 static const char btnStop[] PROGMEM_I1 = ISTR("Stop");
 static const char btnDisableMMU[] PROGMEM_I1 = ISTR("Disable");
-static const char btnMore[] PROGMEM_I1 = ISTR("More"); // @@TODO add that downwards facing >> character
+static const char btnMore[] PROGMEM_I1 = ISTR("More\x01");
 
 // We have 8 different operations/buttons at this time, so we need at least 4 bits to encode each.
 // Since one of the buttons is always "More", we can skip that one.

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -330,7 +330,7 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::Unload, ButtonOperations::Continue),
     Btns(ButtonOperations::StopPrint, ButtonOperations::RestartMMU),
     Btns(ButtonOperations::RestartMMU, ButtonOperations::NoOperation),
-    Btns(ButtonOperations::NoOperation, ButtonOperations::DisableMMU),
+    Btns(ButtonOperations::DisableMMU, ButtonOperations::NoOperation),
     Btns(ButtonOperations::RestartMMU, ButtonOperations::NoOperation),
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),
 };

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -243,17 +243,20 @@ static const char * const errorDescs[] PROGMEM = {
     descRUNTIME_ERROR,
 };
 
+#define BUTTON_OP_HIGH_NIBBLE_MSK 0xF0
+#define BUTTON_OP_LOW_NIBBLE_MSK  0x0F
+
 /// Will be mapped onto dialog button responses in the FW
 /// Those responses have their unique+translated texts as well
 enum class ButtonOperations : uint8_t {
-    NoOperation,
-    Retry,
-    SlowLoad,
-    Continue,
-    RestartMMU,
-    Unload,
-    StopPrint,
-    DisableMMU,
+    NoOperation = 0,
+    Retry       = 1,
+    SlowLoad    = 2,
+    Continue    = 3,
+    RestartMMU  = 4,
+    Unload      = 5,
+    StopPrint   = 6,
+    DisableMMU  = 7,
 };
 
 // we have max 3 buttons/operations to select from
@@ -270,6 +273,17 @@ static const char btnUnload[] PROGMEM_I1 = ISTR("Unload");
 static const char btnStop[] PROGMEM_I1 = ISTR("Stop");
 static const char btnDisableMMU[] PROGMEM_I1 = ISTR("Disable");
 static const char btnMore[] PROGMEM_I1 = ISTR("More\x01");
+
+// Used to parse the buttons from Btns().
+static const char * const btnOperation[] PROGMEM = {
+    btnRetry,
+    btnSlowLoad,
+    btnContinue,
+    btnRestartMMU,
+    btnUnload,
+    btnStop,
+    btnDisableMMU
+};
 
 // We have 8 different operations/buttons at this time, so we need at least 4 bits to encode each.
 // Since one of the buttons is always "More", we can skip that one.

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -1,9 +1,11 @@
 // Extracted from Prusa-Error-Codes repo
 // Subject to automation and optimization
+// BEWARE - this file shall be included only into mmu2_error_converter.cpp, not anywhere else!
 #pragma once
 #include "inttypes.h"
 #include "../language.h"
 #include <avr/pgmspace.h>
+#include "buttons.h"
 
 namespace MMU2 {
 
@@ -72,7 +74,7 @@ typedef enum : uint16_t {
 // and inadvertedly falls back to copying the whole structure into RAM (which is obviously unwanted).
 // But since this file ought to be generated in the future from yaml prescription,
 // it really makes no difference if there are "nice" data structures or plain arrays.
-static const uint16_t errorCodes[] PROGMEM = {
+static const constexpr uint16_t errorCodes[] PROGMEM = {
     ERR_MECHANICAL_FINDA_DIDNT_TRIGGER,
     ERR_MECHANICAL_FINDA_DIDNT_GO_OFF,
     ERR_MECHANICAL_FSENSOR_DIDNT_TRIGGER,
@@ -260,19 +262,6 @@ static const char * const errorDescs[] PROGMEM = {
     descUNLOAD_MANUALLY
 };
 
-
-/// Will be mapped onto dialog button responses in the FW
-/// Those responses have their unique+translated texts as well
-enum class ButtonOperations : uint8_t {
-    NoOperation = 0,
-    Retry       = 1,
-    Continue    = 2,
-    RestartMMU  = 3,
-    Unload      = 4,
-    StopPrint   = 5,
-    DisableMMU  = 6,
-};
-
 // we have max 3 buttons/operations to select from
 // one of them is "More" to show the explanation text normally hidden in the next screens.
 // 01234567890123456789
@@ -296,10 +285,6 @@ static const char * const btnOperation[] PROGMEM = {
     btnStop,
     btnDisableMMU
 };
-
-// Helper macros to parse the operations from Btns()
-#define BUTTON_OP_HI_NIBBLE(X) ( ( X & 0xF0 ) >> 4 )
-#define BUTTON_OP_LO_NIBBLE(X) ( X & 0x0F )
 
 // We have 8 different operations/buttons at this time, so we need at least 4 bits to encode each.
 // Since one of the buttons is always "More", we can skip that one.
@@ -349,5 +334,9 @@ static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::RestartMMU, ButtonOperations::NoOperation),
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),
 };
+
+static_assert( sizeof(errorCodes) / sizeof(errorCodes[0]) == sizeof(errorDescs) / sizeof (errorDescs[0]));
+static_assert( sizeof(errorCodes) / sizeof(errorCodes[0]) == sizeof(errorTitles) / sizeof (errorTitles[0]));
+static_assert( sizeof(errorCodes) / sizeof(errorCodes[0]) == sizeof(errorButtons) / sizeof (errorButtons[0]));
 
 } // namespace MMU2

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -266,11 +266,11 @@ static const char * const errorDescs[] PROGMEM = {
 enum class ButtonOperations : uint8_t {
     NoOperation = 0,
     Retry       = 1,
-    Continue    = 3,
-    RestartMMU  = 4,
-    Unload      = 5,
-    StopPrint   = 6,
-    DisableMMU  = 7,
+    Continue    = 2,
+    RestartMMU  = 3,
+    Unload      = 4,
+    StopPrint   = 5,
+    DisableMMU  = 6,
 };
 
 // we have max 3 buttons/operations to select from
@@ -290,7 +290,6 @@ static const char btnMore[] PROGMEM_I1 = ISTR("More\x01");
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {
     btnRetry,
-    btnSlowLoad,
     btnContinue,
     btnRestartMMU,
     btnUnload,

--- a/Firmware/mmu2_error_converter.cpp
+++ b/Firmware/mmu2_error_converter.cpp
@@ -29,6 +29,9 @@ static constexpr uint8_t FindErrorIndex(uint16_t pec) {
 
 // check that the searching algoritm works
 static_assert( FindErrorIndex(ERR_MECHANICAL_FINDA_DIDNT_TRIGGER) == 0);
+static_assert( FindErrorIndex(ERR_MECHANICAL_FINDA_DIDNT_GO_OFF) == 1);
+static_assert( FindErrorIndex(ERR_MECHANICAL_FSENSOR_DIDNT_TRIGGER) == 2);
+static_assert( FindErrorIndex(ERR_MECHANICAL_FSENSOR_DIDNT_GO_OFF) == 3);
 
 uint8_t PrusaErrorCodeIndex(uint16_t ec) {
     switch (ec) {
@@ -132,7 +135,8 @@ uint8_t PrusaErrorButtons(uint8_t i){
 }
 
 const char * const PrusaErrorButtonTitle(uint8_t bi){
-    return (const char * const)pgm_read_ptr(btnOperation + bi);
+    // -1 represents the hidden NoOperation button which is not drawn in any way
+    return (const char * const)pgm_read_ptr(btnOperation + bi - 1);
 }
 
 const char * const PrusaErrorButtonMore(){

--- a/Firmware/mmu2_error_converter.h
+++ b/Firmware/mmu2_error_converter.h
@@ -3,6 +3,32 @@
 #include <stddef.h>
 
 namespace MMU2 {
-const uint16_t MMUErrorCodeIndex(uint16_t ec);
-void TranslateErr(uint16_t ec, char *dst, size_t dstSize);
-}
+
+/// Translates MMU2::ErrorCode into an index of Prusa-Error-Codes
+/// Basically this is the way to obtain an index into all other functions in this API
+uint8_t PrusaErrorCodeIndex(uint16_t ec);
+
+/// @returns pointer to a PROGMEM string representing the Title of the Prusa-Error-Codes error
+/// @param i index of the error - obtained by calling ErrorCodeIndex
+const char * const PrusaErrorTitle(uint8_t i);
+
+/// @returns pointer to a PROGMEM string representing the multi-page Description of the Prusa-Error-Codes error
+/// @param i index of the error - obtained by calling ErrorCodeIndex
+const char * const PrusaErrorDesc(uint8_t i);
+
+/// @returns the actual numerical value of the Prusa-Error-Codes error
+/// @param i index of the error - obtained by calling ErrorCodeIndex
+uint16_t PrusaErrorCode(uint8_t i);
+
+/// @returns Btns pair of buttons for a particular Prusa-Error-Codes error
+/// @param i index of the error - obtained by calling ErrorCodeIndex
+uint8_t PrusaErrorButtons(uint8_t i);
+
+/// @returns pointer to a PROGMEM string representing the Title of a button
+/// @param i index of the error - obtained by calling PrusaErrorButtons + extracting low or high nibble from the Btns pair
+const char * const PrusaErrorButtonTitle(uint8_t bi);
+
+/// @returns pointer to a PROGMEM string representing the "More" button
+const char * const PrusaErrorButtonMore();
+
+} // namespace MMU2

--- a/Firmware/mmu2_error_converter.h
+++ b/Firmware/mmu2_error_converter.h
@@ -3,5 +3,6 @@
 #include <stddef.h>
 
 namespace MMU2 {
+const uint16_t MMUErrorCodeIndex(uint16_t ec);
 void TranslateErr(uint16_t ec, char *dst, size_t dstSize);
 }

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -49,7 +49,7 @@ back_to_choices:
     lcd_update_enable(false);
      
     // Print title and header
-    lcd_printf_P(PSTR("%S\nprusa3d.com/ERR04%hu"), _T(PrusaErrorTitle(ei)), PrusaErrorCode(ei) );
+    lcd_printf_P(PSTR("%.20S\nprusa3d.com/ERR04%hu"), _T(PrusaErrorTitle(ei)), PrusaErrorCode(ei) );
 
     // Render the choices and store selection in 'choice_selected'
     choice_selected = lcd_show_multiscreen_message_with_choices_and_wait_P(

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -56,8 +56,8 @@ back_to_choices:
         NULL, // NULL, since title screen is not in PROGMEM
         false,
         two_choices ? LEFT_BUTTON_CHOICE : MIDDLE_BUTTON_CHOICE,
-        _T(PrusaErrorButtonTitle(button_low_nibble - 1)),
-        _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_high_nibble - 1)),
+        _T(PrusaErrorButtonTitle(button_low_nibble)),
+        _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_high_nibble)),
         two_choices ? nullptr : _T(PrusaErrorButtonMore()),
         two_choices ? 
             10 // If two choices, allow the first choice to have more characters

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -57,7 +57,7 @@ back_to_choices:
     choice_selected = lcd_show_multiscreen_message_with_choices_and_wait_P(
         NULL, // NULL, since title screen is not in PROGMEM
         false,
-        false,
+        two_choices ? LEFT_BUTTON_CHOICE : MIDDLE_BUTTON_CHOICE,
         static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_low_nibble - 1])),
         two_choices ?
             btnMore

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -67,12 +67,11 @@ back_to_choices:
         two_choices ? nullptr : btnMore,
         two_choices ? 
             10 // If two choices, allow the first choice to have more characters
-            : 7,
-        13
+            : 7
     );
 
-    if ((two_choices && choice_selected == 1)      // Two choices and middle button selected
-        || (!two_choices && choice_selected == 2)) // Three choices and right most button selected
+    if ((two_choices && choice_selected == MIDDLE_BUTTON_CHOICE)      // Two choices and middle button selected
+        || (!two_choices && choice_selected == RIGHT_BUTTON_CHOICE)) // Three choices and right most button selected
     {
         // 'More' show error description
         lcd_show_fullscreen_message_and_wait_P(
@@ -81,7 +80,7 @@ back_to_choices:
 
         // Return back to the choice menu
         goto back_to_choices;
-    } else if(choice_selected == 1) {
+    } else if(choice_selected == MIDDLE_BUTTON_CHOICE) {
         // TODO: User selected middle choice, not sure what to do.
         //       At the moment just return to the status screen
         switch (button_high_nibble)

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -32,9 +32,9 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
 
     // Read and determine what operations should be shown on the menu
     // Note: uint16_t is used here to avoid compiler warning. uint8_t is only half the size of void*
-    uint8_t button_operation = reinterpret_cast<uint16_t>(const_cast<void*>(pgm_read_ptr(&errorButtons[ei])));
-    uint8_t button_high_nibble = (button_operation & BUTTON_OP_HIGH_NIBBLE_MSK) >> 4;
-    uint8_t button_low_nibble = button_operation & BUTTON_OP_LOW_NIBBLE_MSK;
+    const uint8_t button_operation   = reinterpret_cast<uint16_t>(const_cast<void*>(pgm_read_ptr(&errorButtons[ei])));
+    const uint8_t button_high_nibble = BUTTON_OP_HI_NIBBLE(button_operation);
+    const uint8_t button_low_nibble  = BUTTON_OP_LO_NIBBLE(button_operation);
 
     // Check if the menu should have three or two choices
     if (button_low_nibble == (uint8_t)ButtonOperations::NoOperation)

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -37,7 +37,7 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
     const uint8_t button_low_nibble  = BUTTON_OP_LO_NIBBLE(button_operation);
 
     // Check if the menu should have three or two choices
-    if (button_low_nibble == (uint8_t)ButtonOperations::NoOperation)
+    if (button_high_nibble == (uint8_t)ButtonOperations::NoOperation)
     {
         // Two operations not specified, the error menu should only show two choices
         two_choices = true;
@@ -58,9 +58,7 @@ back_to_choices:
         NULL, // NULL, since title screen is not in PROGMEM
         false,
         false,
-        two_choices ?
-            static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_high_nibble - 1]))
-            : static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_low_nibble - 1])),
+        static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_low_nibble - 1])),
         two_choices ?
             btnMore
             : static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_high_nibble - 1])),
@@ -86,7 +84,6 @@ back_to_choices:
         switch (button_high_nibble)
         {
         case (uint8_t)ButtonOperations::Retry:
-        case (uint8_t)ButtonOperations::SlowLoad:
         case (uint8_t)ButtonOperations::Continue:
         case (uint8_t)ButtonOperations::RestartMMU:
         case (uint8_t)ButtonOperations::Unload:
@@ -100,13 +97,9 @@ back_to_choices:
     } else {
         // TODO: User selected the left most choice, not sure what to do.
         //       At the moment just return to the status screen
-        switch ( two_choices ?
-            button_high_nibble
-            : button_low_nibble
-        )
+        switch (button_low_nibble)
         {
         case (uint8_t)ButtonOperations::Retry:
-        case (uint8_t)ButtonOperations::SlowLoad:
         case (uint8_t)ButtonOperations::Continue:
         case (uint8_t)ButtonOperations::RestartMMU:
         case (uint8_t)ButtonOperations::Unload:

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -1,4 +1,7 @@
 #include "mmu2_reporting.h"
+#include "mmu2_error_converter.h"
+#include "mmu2/error_codes.h"
+#include "mmu2/errors_list.h"
 #include "ultralcd.h"
 
 namespace MMU2 {
@@ -16,8 +19,106 @@ void EndReport(CommandInProgress cip, uint16_t ec) {
 }
 
 void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
-    // @@TODO - display an error screen - we still don't know how that will look like
-    // The only thing we know is the fact, that the screen must not block the MMU automaton
+    //! Show an error screen
+    //! When an MMU error occurs, the LCD content will look like this:
+    //! |01234567890123456789|
+    //! |MMU FW update needed|     <- title/header of the error: max 20 characters
+    //! |prusa3d.com/ERR04504|     <- URL 20 characters
+    //! |                    |     <- empty line
+    //! |>Retry  >Done >MoreW|     <- buttons
+    const uint16_t ei = MMUErrorCodeIndex((uint16_t)ec);
+    uint8_t choice_selected = 0;
+    bool two_choices = false;
+
+    // Read and determine what operations should be shown on the menu
+    // Note: uint16_t is used here to avoid compiler warning. uint8_t is only half the size of void*
+    uint8_t button_operation = reinterpret_cast<uint16_t>(const_cast<void*>(pgm_read_ptr(&errorButtons[ei])));
+    uint8_t button_high_nibble = (button_operation & BUTTON_OP_HIGH_NIBBLE_MSK) >> 4;
+    uint8_t button_low_nibble = button_operation & BUTTON_OP_LOW_NIBBLE_MSK;
+
+    // Check if the menu should have three or two choices
+    if (button_low_nibble == (uint8_t)ButtonOperations::NoOperation)
+    {
+        // Two operations not specified, the error menu should only show two choices
+        two_choices = true;
+    }
+
+back_to_choices:
+    lcd_clear();
+    lcd_update_enable(false);
+
+    // Print title and header
+    lcd_printf_P(PSTR("%S\nprusa3d.com/ERR04%hu"),
+        static_cast<const char * const>(pgm_read_ptr(&errorTitles[ei])),
+        reinterpret_cast<uint16_t>(const_cast<void*>(pgm_read_ptr(&errorCodes[ei])))
+    );
+
+    // Render the choices and store selection in 'choice_selected'
+    choice_selected = lcd_show_multiscreen_message_with_choices_and_wait_P(
+        NULL, // NULL, since title screen is not in PROGMEM
+        false,
+        false,
+        two_choices ?
+            static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_high_nibble - 1]))
+            : static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_low_nibble - 1])),
+        two_choices ?
+            btnMore
+            : static_cast<const char * const>(pgm_read_ptr(&btnOperation[button_high_nibble - 1])),
+        two_choices ? nullptr : btnMore,
+        two_choices ? 
+            10 // If two choices, allow the first choice to have more characters
+            : 7,
+        13
+    );
+
+    if ((two_choices && choice_selected == 1)      // Two choices and middle button selected
+        || (!two_choices && choice_selected == 2)) // Three choices and right most button selected
+    {
+        // 'More' show error description
+        lcd_show_fullscreen_message_and_wait_P(
+            static_cast<const char * const>(pgm_read_ptr(&errorDescs[ei]))
+        );
+
+        // Return back to the choice menu
+        goto back_to_choices;
+    } else if(choice_selected == 1) {
+        // TODO: User selected middle choice, not sure what to do.
+        //       At the moment just return to the status screen
+        switch (button_high_nibble)
+        {
+        case (uint8_t)ButtonOperations::Retry:
+        case (uint8_t)ButtonOperations::SlowLoad:
+        case (uint8_t)ButtonOperations::Continue:
+        case (uint8_t)ButtonOperations::RestartMMU:
+        case (uint8_t)ButtonOperations::Unload:
+        case (uint8_t)ButtonOperations::StopPrint:
+        case (uint8_t)ButtonOperations::DisableMMU:
+        default:
+            lcd_update_enable(true);
+            lcd_return_to_status();
+            break;
+        }
+    } else {
+        // TODO: User selected the left most choice, not sure what to do.
+        //       At the moment just return to the status screen
+        switch ( two_choices ?
+            button_high_nibble
+            : button_low_nibble
+        )
+        {
+        case (uint8_t)ButtonOperations::Retry:
+        case (uint8_t)ButtonOperations::SlowLoad:
+        case (uint8_t)ButtonOperations::Continue:
+        case (uint8_t)ButtonOperations::RestartMMU:
+        case (uint8_t)ButtonOperations::Unload:
+        case (uint8_t)ButtonOperations::StopPrint:
+        case (uint8_t)ButtonOperations::DisableMMU:
+        default:
+            lcd_update_enable(true);
+            lcd_return_to_status();
+            break;
+        }
+    }
 }
 
 void ReportProgressHook(CommandInProgress cip, uint16_t ec) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3113,7 +3113,7 @@ const char* lcd_display_message_fullscreen_P(const char *msg)
  */
 void lcd_show_fullscreen_message_and_wait_P(const char *msg)
 {
-    LcdUpdateDisabler lcdUpdateDisabler;
+    lcd_update_enable(false);
     const char *msg_next = lcd_display_message_fullscreen_P(msg);
     bool multi_screen = msg_next != NULL;
 	lcd_set_custom_characters_nextpage();

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -671,6 +671,7 @@ void lcdui_print_status_line(void) {
             break;
         case CustomMsg::MMUProgress:
             // set up at mmu2_reporting.cpp, just do nothing here
+            lcd_print(lcd_status_message);
             break;
         }
     }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3178,7 +3178,7 @@ lcd_wait_for_click_delay(0);
 }
 
 //! @brief Show multiple screen message with yes and no possible choices and wait with possible timeout
-//! @param msg Message to show
+//! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
 //! @retval 1 yes choice selected by user
@@ -3188,8 +3188,21 @@ int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allo
 {
     return lcd_show_multiscreen_message_two_choices_and_wait_P(msg, allow_timeouting, default_yes, _T(MSG_YES), _T(MSG_NO));
 }
-//! @brief Show multiple screen message with two possible choices and wait with possible timeout
-//! @param msg Message to show
+//! @brief Show a two-choice prompt on the last line of the LCD
+//! @param first_selected Show first choice as selected if true, the second otherwise
+//! @param first_choice text caption of first possible choice
+//! @param second_choice text caption of second possible choice
+void lcd_show_two_choices_prompt_P(bool first_selected, const char *first_choice, const char *second_choice)
+{
+    lcd_set_cursor(0, 3);
+    lcd_print(first_selected? '>': ' ');
+    lcd_puts_P(first_choice);
+    lcd_set_cursor(7, 3);
+    lcd_print(!first_selected? '>': ' ');
+    lcd_puts_P(second_choice);
+}
+//! @brief Show single or multiple screen message with two possible choices and wait with possible timeout
+//! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_first if true, fist choice is selected by default, otherwise second choice is preselected
 //! @param first_choice text caption of first possible choice
@@ -3200,15 +3213,18 @@ int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allo
 int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_first,
         const char *first_choice, const char *second_choice)
 {
-	const char *msg_next = lcd_display_message_fullscreen_P(msg);
+	const char *msg_next = msg? lcd_display_message_fullscreen_P(msg) : NULL;
 	bool multi_screen = msg_next != NULL;
+
+    // Initial status/prompt on single-screen messages
 	bool yes = default_first ? true : false;
+	if (!msg_next) lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
 
 	// Wait for user confirmation or a timeout.
 	unsigned long previous_millis_cmd = _millis();
-	int8_t        enc_dif = lcd_encoder_diff;
+	int8_t enc_dif = lcd_encoder_diff;
 	lcd_consume_click();
-	//KEEPALIVE_STATE(PAUSED_FOR_USER);
+	KEEPALIVE_STATE(PAUSED_FOR_USER);
 	for (;;) {
 		for (uint8_t i = 0; i < 100; ++i) {
 			delay_keep_alive(50);
@@ -3219,19 +3235,13 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 
 			if (abs(enc_dif - lcd_encoder_diff) > 4) {
 				if (msg_next == NULL) {
-					lcd_set_cursor(0, 3);
-					if (enc_dif < lcd_encoder_diff && yes) {
-						lcd_print(' ');
-						lcd_putc_at(7, 3, '>');
-						yes = false;
-						Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-					}
-					else if (enc_dif > lcd_encoder_diff && !yes) {
-						lcd_print('>');
-						lcd_putc_at(7, 3, ' ');
-						yes = true;
-						Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-					}
+                    if ((enc_dif < lcd_encoder_diff && yes) ||
+                        ((enc_dif > lcd_encoder_diff && !yes)))
+                    {
+                        yes = !yes;
+                        lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
+                        Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
+                    }
 					enc_dif = lcd_encoder_diff;
 				}
 				else {
@@ -3242,7 +3252,7 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 			if (lcd_clicked()) {
 				Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
 				if (msg_next == NULL) {
-					//KEEPALIVE_STATE(IN_HANDLER);
+					KEEPALIVE_STATE(IN_HANDLER);
 					lcd_set_custom_characters();
 					return yes;
 				}
@@ -3256,17 +3266,12 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 			msg_next = lcd_display_message_fullscreen_P(msg_next);
 		}
 		if (msg_next == NULL) {
-			lcd_set_cursor(0, 3);
-			if (yes) lcd_print('>');
-			lcd_puts_at_P(1, 3, first_choice);
-			lcd_set_cursor(7, 3);
-			if (!yes) lcd_print('>');
-			lcd_puts_at_P(8, 3, second_choice);
+            lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
 		}
 	}
 }
 
-//! @brief Display and wait for a Yes/No choice using the last two lines of the LCD
+//! @brief Display and wait for a Yes/No choice using the last line of the LCD
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
 //! @retval 1 yes choice selected by user
@@ -3274,60 +3279,11 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 //! @retval -1 screen timed out
 int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
 {
-	if (default_yes) {
-		lcd_putc_at(0, 2, '>');
-		lcd_puts_P(_T(MSG_YES));
-		lcd_puts_at_P(1, 3, _T(MSG_NO));
-	}
-	else {
-		lcd_puts_at_P(1, 2, _T(MSG_YES));
-		lcd_putc_at(0, 3, '>');
-		lcd_puts_P(_T(MSG_NO));
-	}
-	int8_t retval = default_yes ? true : false;
-
-	// Wait for user confirmation or a timeout.
-	unsigned long previous_millis_cmd = _millis();
-	int8_t        enc_dif = lcd_encoder_diff;
-	lcd_consume_click();
-	KEEPALIVE_STATE(PAUSED_FOR_USER);
-	for (;;) {
-		if (allow_timeouting && _millis() - previous_millis_cmd > LCD_TIMEOUT_TO_STATUS)
-		{
-		    retval = -1;
-		    break;
-		}
-		manage_heater();
-		manage_inactivity(true);
-		if (abs(enc_dif - lcd_encoder_diff) > 4) {
-			lcd_set_cursor(0, 2);
-				if (enc_dif < lcd_encoder_diff && retval) {
-					lcd_print(' ');
-					lcd_putc_at(0, 3, '>');
-					retval = 0;
-					Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-
-				}
-				else if (enc_dif > lcd_encoder_diff && !retval) {
-					lcd_print('>');
-					lcd_putc_at(0, 3, ' ');
-					retval = 1;
-					Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
-				}
-				enc_dif = lcd_encoder_diff;
-		}
-		if (lcd_clicked()) {
-			Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
-			KEEPALIVE_STATE(IN_HANDLER);
-			break;
-		}
-	}
-    lcd_encoder_diff = 0;
-    return retval;
+    return lcd_show_multiscreen_message_yes_no_and_wait_P(NULL, allow_timeouting, default_yes);
 }
 
 //! @brief Show single screen message with yes and no possible choices and wait with possible timeout
-//! @param msg Message to show
+//! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
 //! @retval 1 yes choice selected by user
@@ -3336,8 +3292,7 @@ int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
 //! @relates lcd_show_yes_no_and_wait
 int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
 {
-    lcd_display_message_fullscreen_P(msg);
-    return lcd_show_yes_no_and_wait(allow_timeouting, default_yes);
+    return lcd_show_multiscreen_message_yes_no_and_wait_P(msg, allow_timeouting, default_yes);
 }
 
 void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3183,13 +3183,13 @@ lcd_wait_for_click_delay(0);
 //! @brief Show multiple screen message with yes and no possible choices and wait with possible timeout
 //! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
+//! @param default_selection if 0, 'Yes' choice is selected by default, otherwise 'No' choice is preselected
 //! @retval 0 yes choice selected by user
 //! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
-int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes) //currently just max. n*4 + 3 lines supported (set in language header files)
+int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection) //currently just max. n*4 + 3 lines supported (set in language header files)
 {
-    return lcd_show_multiscreen_message_with_choices_and_wait_P(msg, allow_timeouting, default_yes, _T(MSG_YES), _T(MSG_NO), nullptr, 10);
+    return lcd_show_multiscreen_message_with_choices_and_wait_P(msg, allow_timeouting, default_selection, _T(MSG_YES), _T(MSG_NO), nullptr, 10);
 }
 //! @brief Show a two-choice prompt on the last line of the LCD
 //! @param selected Show first choice as selected if true, the second otherwise
@@ -3220,7 +3220,7 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 //! @brief Show single or multiple screen message with two possible choices and wait with possible timeout
 //! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting bool, if true, allows time outing of the screen
-//! @param default_first uint8_t, Control which choice is selected first. 0: left most, 1: middle, 2: right most choice. The first choice is selected by default
+//! @param default_selection uint8_t, Control which choice is selected first. 0: left most, 1: middle, 2: right most choice. The left most choice is selected by default
 //! @param first_choice text caption of first possible choice. Must be in PROGMEM
 //! @param second_choice text caption of second possible choice. Must be in PROGMEM
 //! @param third_choice text caption of second possible choice. Must be in PROGMEM. When not set to nullptr first_choice and second_choice may not be more than 5 characters long.
@@ -3229,7 +3229,7 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 //! @retval 1 first choice selected by user
 //! @retval 2 third choice selected by user
 //! @retval -1 screen timed out (only possible if allow_timeouting is true)
-int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_first,
+int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection,
         const char *first_choice, const char *second_choice, const char *third_choice, uint8_t second_col)
 {
 	const char *msg_next = msg ? lcd_display_message_fullscreen_P(msg) : NULL;
@@ -3237,7 +3237,7 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 	lcd_set_custom_characters_nextpage();
 
 	// Initial status/prompt on single-screen messages
-	uint8_t current_selection = default_first ? MIDDLE_BUTTON_CHOICE : LEFT_BUTTON_CHOICE;
+	uint8_t current_selection = default_selection;
 	if (!msg_next) {
 		lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
 	}
@@ -3310,26 +3310,26 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 
 //! @brief Display and wait for a Yes/No choice using the last line of the LCD
 //! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
+//! @param default_selection if 0, 'Yes' choice is selected by default, otherwise 'No' choice is preselected
 //! @retval 0 yes choice selected by user
 //! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
-int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
+int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, uint8_t default_selection)
 {
-    return lcd_show_multiscreen_message_yes_no_and_wait_P(NULL, allow_timeouting, default_yes);
+    return lcd_show_multiscreen_message_yes_no_and_wait_P(NULL, allow_timeouting, default_selection);
 }
 
 //! @brief Show single screen message with yes and no possible choices and wait with possible timeout
 //! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
-//! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
+//! @param default_selection if 0, 'Yes' choice is selected by default, otherwise 'No' choice is preselected
 //! @retval 0 yes choice selected by user
 //! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
 //! @relates lcd_show_yes_no_and_wait
-int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
+int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection)
 {
-    return lcd_show_multiscreen_message_yes_no_and_wait_P(msg, allow_timeouting, default_yes);
+    return lcd_show_multiscreen_message_yes_no_and_wait_P(msg, allow_timeouting, default_selection);
 }
 
 void lcd_bed_calibration_show_result(BedSkewOffsetDetectionResultType result, uint8_t point_too_far_mask)

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3229,8 +3229,8 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 //! @retval 1 first choice selected by user
 //! @retval 2 third choice selected by user
 //! @retval -1 screen timed out (only possible if allow_timeouting is true)
-int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection,
-        const char *first_choice, const char *second_choice, const char *third_choice, uint8_t second_col)
+int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char * const msg, bool allow_timeouting, uint8_t default_selection,
+       const char * const first_choice, const char * const second_choice, const char * const third_choice, uint8_t second_col)
 {
 	const char *msg_next = msg ? lcd_display_message_fullscreen_P(msg) : NULL;
 	bool multi_screen = msg_next != NULL;

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2298,7 +2298,7 @@ void show_preheat_nozzle_warning()
 void lcd_load_filament_color_check()
 {
 	bool clean = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_CLEAN), false, true);
-	while (!clean) {
+	while (clean == MIDDLE_BUTTON_CHOICE) {
 		lcd_update_enable(true);
 		lcd_update(2);
 		load_filament_final_feed();
@@ -3184,8 +3184,8 @@ lcd_wait_for_click_delay(0);
 //! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
-//! @retval 1 yes choice selected by user
-//! @retval 0 no choice selected by user
+//! @retval 0 yes choice selected by user
+//! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
 int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes) //currently just max. n*4 + 3 lines supported (set in language header files)
 {
@@ -3311,8 +3311,8 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 //! @brief Display and wait for a Yes/No choice using the last line of the LCD
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
-//! @retval 1 yes choice selected by user
-//! @retval 0 no choice selected by user
+//! @retval 0 yes choice selected by user
+//! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
 int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
 {
@@ -3323,8 +3323,8 @@ int8_t lcd_show_yes_no_and_wait(bool allow_timeouting, bool default_yes)
 //! @param msg Message to show. If NULL, do not clear the screen and handle choice selection only.
 //! @param allow_timeouting if true, allows time outing of the screen
 //! @param default_yes if true, yes choice is selected by default, otherwise no choice is preselected
-//! @retval 1 yes choice selected by user
-//! @retval 0 no choice selected by user
+//! @retval 0 yes choice selected by user
+//! @retval 1 no choice selected by user
 //! @retval -1 screen timed out
 //! @relates lcd_show_yes_no_and_wait
 int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes)
@@ -3973,7 +3973,7 @@ void menu_setlang(unsigned char lang)
 {
 	if (!lang_select(lang))
 	{
-		if (lcd_show_fullscreen_message_yes_no_and_wait_P(_i("Copy selected language?"), false, true))////MSG_COPY_SEL_LANG c=20 r=3
+		if (lcd_show_fullscreen_message_yes_no_and_wait_P(_i("Copy selected language?"), false, true) == LEFT_BUTTON_CHOICE)////MSG_COPY_SEL_LANG c=20 r=3
 			lang_boot_update_start(lang);
 		lcd_update_enable(true);
 		lcd_clear();
@@ -4174,7 +4174,7 @@ void lcd_v2_calibration()
 	    }
 	    else
 	    {
-	        loaded = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, true);
+	        loaded = !lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), false, true);
 	        lcd_update_enabled = true;
 
 	    }
@@ -4204,7 +4204,7 @@ void lcd_v2_calibration()
 void lcd_wizard() {
 	bool result = true;
 	if (calibration_status() != CALIBRATION_STATUS_ASSEMBLED) {
-		result = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Running Wizard will delete current calibration results and start from the beginning. Continue?"), false, false);////MSG_WIZARD_RERUN c=20 r=7
+		result = !lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Running Wizard will delete current calibration results and start from the beginning. Continue?"), false, false);////MSG_WIZARD_RERUN c=20 r=7
 	}
 	if (result) {
 		calibration_status_store(CALIBRATION_STATUS_ASSEMBLED);
@@ -4367,10 +4367,10 @@ void lcd_wizard(WizState state)
 				state = S::Restore;
 			} else {
 				wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_T(MSG_WIZARD_WELCOME), false, true);
-				if (wizard_event) {
+				if (wizard_event == LEFT_BUTTON_CHOICE) {
 					state = S::Restore;
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 1);
-				} else {
+				} else { // MIDDLE_BUTTON_CHOICE
 					eeprom_update_byte((uint8_t*)EEPROM_WIZARD_ACTIVE, 0);
 					end = true;
 				}
@@ -4406,7 +4406,9 @@ void lcd_wizard(WizState state)
 			lcd_show_fullscreen_message_and_wait_P(_i("Now remove the test print from steel sheet."));////MSG_REMOVE_TEST_PRINT c=20 r=4
 			lcd_show_fullscreen_message_and_wait_P(_i("I will run z calibration now."));////MSG_WIZARD_Z_CAL c=20 r=8
 			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_STEEL_SHEET_CHECK), false, false);
-			if (!wizard_event) lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
+			if (wizard_event == MIDDLE_BUTTON_CHOICE) {
+				lcd_show_fullscreen_message_and_wait_P(_T(MSG_PLACE_STEEL_SHEET));
+			}
 			wizard_event = gcode_M45(true, 0);
 			if (wizard_event) {
 				//current filament needs to be unloaded and then new filament should be loaded
@@ -4427,16 +4429,10 @@ void lcd_wizard(WizState state)
 		    //start to preheat nozzle and bed to save some time later
 			setTargetHotend(PLA_PREHEAT_HOTEND_TEMP, 0);
 			setTargetBed(PLA_PREHEAT_HPB_TEMP);
-			if (MMU2::mmu2.Enabled())
-			{
-			    wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), true);
-			} else
-			{
-			    wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), true);
-			}
-			if (wizard_event) state = S::Lay1CalCold;
-			else
-			{
+			wizard_event = lcd_show_fullscreen_message_yes_no_and_wait_P(_T(MSG_FILAMENT_LOADED), true);
+			if (wizard_event == LEFT_BUTTON_CHOICE) {
+				state = S::Lay1CalCold;
+			} else { // MIDDLE_BUTTON_CHOICE
 			    if(MMU2::mmu2.Enabled()) state = S::LoadFilCold;
 			    else state = S::Preheat;
 			}
@@ -4467,7 +4463,7 @@ void lcd_wizard(WizState state)
             break;
 		case S::RepeatLay1Cal:
 			wizard_event = lcd_show_multiscreen_message_yes_no_and_wait_P(_i("Do you want to repeat last step to readjust distance between nozzle and heatbed?"), false);////MSG_WIZARD_REPEAT_V2_CAL c=20 r=7
-			if (wizard_event)
+			if (wizard_event == LEFT_BUTTON_CHOICE)
 			{
 				lcd_show_fullscreen_message_and_wait_P(_i("Please clean heatbed and then press the knob."));////MSG_WIZARD_CLEAN_HEATBED c=20 r=8
 				state = S::Lay1CalCold;
@@ -5422,7 +5418,7 @@ char reset_menu() {
 static void lcd_disable_farm_mode()
 {
 	int8_t disable = lcd_show_fullscreen_message_yes_no_and_wait_P(PSTR("Disable farm mode?"), true, false); //allow timeouting, default no
-	if (disable)
+	if (disable == LEFT_BUTTON_CHOICE)
 	{
 		enquecommand_P(PSTR("G99"));
 		lcd_return_to_status();
@@ -7771,8 +7767,7 @@ static void menu_action_sdfile(const char* filename)
   //filename is just a pointer to card.filename, which changes everytime you try to open a file by filename. So you can't use filename directly
   //to open a file. Instead, the cached filename in cmd is used as that one is static for the whole lifetime of this function.
   if (!check_file(cmd + 4)) {
-	  result = lcd_show_fullscreen_message_yes_no_and_wait_P(_i("File incomplete. Continue anyway?"), false, false);////MSG_FILE_INCOMPLETE c=20 r=3
-	  lcd_update_enable(true);
+      result = !lcd_show_fullscreen_message_yes_no_and_wait_P(_i("File incomplete. Continue anyway?"), false, false);////MSG_FILE_INCOMPLETE c=20 r=3
   }
   if (result) {
 	  enquecommand(cmd);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3186,18 +3186,18 @@ lcd_wait_for_click_delay(0);
 //! @retval -1 screen timed out
 int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes) //currently just max. n*4 + 3 lines supported (set in language header files)
 {
-    return lcd_show_multiscreen_message_two_choices_and_wait_P(msg, allow_timeouting, default_yes, _T(MSG_YES), _T(MSG_NO));
+    return lcd_show_multiscreen_message_two_choices_and_wait_P(msg, allow_timeouting, default_yes, _T(MSG_YES), _T(MSG_NO), 10);
 }
 //! @brief Show a two-choice prompt on the last line of the LCD
 //! @param first_selected Show first choice as selected if true, the second otherwise
 //! @param first_choice text caption of first possible choice
 //! @param second_choice text caption of second possible choice
-void lcd_show_two_choices_prompt_P(bool first_selected, const char *first_choice, const char *second_choice)
+void lcd_show_two_choices_prompt_P(bool first_selected, const char *first_choice, const char *second_choice, uint8_t second_col)
 {
     lcd_set_cursor(0, 3);
     lcd_print(first_selected? '>': ' ');
     lcd_puts_P(first_choice);
-    lcd_set_cursor(7, 3);
+    lcd_set_cursor(second_col, 3);
     lcd_print(!first_selected? '>': ' ');
     lcd_puts_P(second_choice);
 }
@@ -3211,14 +3211,14 @@ void lcd_show_two_choices_prompt_P(bool first_selected, const char *first_choice
 //! @retval 0 second choice selected by user
 //! @retval -1 screen timed out
 int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_first,
-        const char *first_choice, const char *second_choice)
+        const char *first_choice, const char *second_choice, uint8_t second_col)
 {
 	const char *msg_next = msg? lcd_display_message_fullscreen_P(msg) : NULL;
 	bool multi_screen = msg_next != NULL;
 
     // Initial status/prompt on single-screen messages
 	bool yes = default_first ? true : false;
-	if (!msg_next) lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
+	if (!msg_next) lcd_show_two_choices_prompt_P(yes, first_choice, second_choice, second_col);
 
 	// Wait for user confirmation or a timeout.
 	unsigned long previous_millis_cmd = _millis();
@@ -3239,7 +3239,7 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
                         ((enc_dif > lcd_encoder_diff && !yes)))
                     {
                         yes = !yes;
-                        lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
+                        lcd_show_two_choices_prompt_P(yes, first_choice, second_choice, second_col);
                         Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
                     }
 					enc_dif = lcd_encoder_diff;
@@ -3266,7 +3266,7 @@ int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool
 			msg_next = lcd_display_message_fullscreen_P(msg_next);
 		}
 		if (msg_next == NULL) {
-            lcd_show_two_choices_prompt_P(yes, first_choice, second_choice);
+            lcd_show_two_choices_prompt_P(yes, first_choice, second_choice, second_col);
 		}
 	}
 }

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3237,9 +3237,9 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 	lcd_set_custom_characters_nextpage();
 
 	// Initial status/prompt on single-screen messages
-	uint8_t yes = default_first ? MIDDLE_BUTTON_CHOICE : LEFT_BUTTON_CHOICE;
+	uint8_t current_selection = default_first ? MIDDLE_BUTTON_CHOICE : LEFT_BUTTON_CHOICE;
 	if (!msg_next) {
-		lcd_show_choices_prompt_P(yes, first_choice, second_choice, second_col, third_choice);
+		lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
 	}
 	// Wait for user confirmation or a timeout.
 	unsigned long previous_millis_cmd = _millis();
@@ -3260,23 +3260,23 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 				if (msg_next == NULL) {
 					if (third_choice)
 					{ // third_choice is not nullptr, safe to dereference
-						if (enc_dif > lcd_encoder_diff && yes != LEFT_BUTTON_CHOICE) {
+						if (enc_dif > lcd_encoder_diff && current_selection != LEFT_BUTTON_CHOICE) {
 							// Rotating knob counter clockwise
-							yes = yes - 1;
-						} else if (enc_dif < lcd_encoder_diff && yes != RIGHT_BUTTON_CHOICE) {
+							current_selection--;
+						} else if (enc_dif < lcd_encoder_diff && current_selection != RIGHT_BUTTON_CHOICE) {
 							// Rotating knob clockwise
-							yes = yes + 1;
+							current_selection++;
 						}
 					} else {
-						if (enc_dif > lcd_encoder_diff && yes != LEFT_BUTTON_CHOICE) {
+						if (enc_dif > lcd_encoder_diff && current_selection != LEFT_BUTTON_CHOICE) {
 							// Rotating knob counter clockwise
-							yes = LEFT_BUTTON_CHOICE;
-						} else if (enc_dif < lcd_encoder_diff && yes != MIDDLE_BUTTON_CHOICE) {
+							current_selection = LEFT_BUTTON_CHOICE;
+						} else if (enc_dif < lcd_encoder_diff && current_selection != MIDDLE_BUTTON_CHOICE) {
 							// Rotating knob clockwise
-							yes = MIDDLE_BUTTON_CHOICE;
+							current_selection = MIDDLE_BUTTON_CHOICE;
 						}
 					}
-					lcd_show_choices_prompt_P(yes, first_choice, second_choice, second_col, third_choice);
+					lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
 					enc_dif = lcd_encoder_diff;
 					Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
 				}
@@ -3291,7 +3291,7 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 					KEEPALIVE_STATE(IN_HANDLER);
 					lcd_set_custom_characters();
 					lcd_update_enable(true);
-					return yes;
+					return current_selection;
 				}
 				else break;
 			}
@@ -3303,7 +3303,7 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, boo
 			msg_next = lcd_display_message_fullscreen_P(msg_next);
 		}
 		if (msg_next == NULL) {
-			lcd_show_choices_prompt_P(yes, first_choice, second_choice, second_col, third_choice);
+			lcd_show_choices_prompt_P(current_selection, first_choice, second_choice, second_col, third_choice);
 		}
 	}
 }

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -76,7 +76,7 @@ extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool defaul
 // 0: no, 1: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 extern int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
-        const char *first_choice, const char *second_choice);
+        const char *first_choice, const char *second_choice, uint8_t second_col = 7);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -76,7 +76,7 @@ extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool defaul
 // 0: no, 1: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 extern int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
-        const char *first_choice, const char *second_choice, uint8_t second_col = 7);
+        const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7, uint8_t third_col = 13);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -75,7 +75,7 @@ extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool default_yes = false);
 // 0: no, 1: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
-extern int8_t lcd_show_multiscreen_message_two_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
+extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
         const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7, uint8_t third_col = 13);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 // Ask the user to move the Z axis up to the end stoppers and let

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -78,9 +78,9 @@ extern void lcd_return_to_status();
 extern void lcd_wait_for_click();
 extern bool lcd_wait_for_click_delay(uint16_t nDelay);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
-// 0: no, 1: yes, -1: timeouted
+// 1: no, 0: yes, -1: timeouted
 extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool default_yes = false);
-// 0: no, 1: yes, -1: timeouted
+// 1: no, 0: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
         const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -64,6 +64,13 @@ void lcd_crash_detect_enable();
 void lcd_crash_detect_disable();
 #endif
 
+enum ButtonChoice
+{
+	LEFT_BUTTON_CHOICE = 0,
+    MIDDLE_BUTTON_CHOICE = 1,
+    RIGHT_BUTTON_CHOICE = 2,
+};
+
 extern const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines);
 extern const char* lcd_display_message_fullscreen_P(const char *msg);
 
@@ -76,7 +83,7 @@ extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool defaul
 // 0: no, 1: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
-        const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7, uint8_t third_col = 13);
+        const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -66,7 +66,7 @@ void lcd_crash_detect_disable();
 
 enum ButtonChoice
 {
-	LEFT_BUTTON_CHOICE = 0,
+    LEFT_BUTTON_CHOICE = 0,
     MIDDLE_BUTTON_CHOICE = 1,
     RIGHT_BUTTON_CHOICE = 2,
 };

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -79,12 +79,12 @@ extern void lcd_wait_for_click();
 extern bool lcd_wait_for_click_delay(uint16_t nDelay);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 // 1: no, 0: yes, -1: timeouted
-extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, bool default_yes = false);
+extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 // 1: no, 0: yes, -1: timeouted
-extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
-extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, bool default_yes,
+extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
+extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection,
         const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7);
-extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, bool default_yes = false);
+extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -82,8 +82,8 @@ extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 // 1: no, 0: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
-extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char *msg, bool allow_timeouting, uint8_t default_selection,
-        const char *first_choice, const char *second_choice, const char *third_choice = nullptr, uint8_t second_col = 7);
+extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char * const msg, bool allow_timeouting, uint8_t default_selection,
+        const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr, uint8_t second_col = 7);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.


### PR DESCRIPTION
See JIRA ticket: https://dev.prusa3d.com/browse/PFW-1312

**Currently the PR is a Draft and is a work in progress!**

TODO:

- [x] I have created an inconsistency in the menus which have choices. Previously the left most choice was 1, and Middle choice was 0. In my changes it is: Left most is 0, Middle is 1 and right most is 2.
- [x] Do we want to return to the status screen after running a MMU command in the menus? => We want to return to the last menu. Example: When running **Load filament** -> **Filament 1** we would like to return back to the **Load filament** menu.
- [x] `third_col` might not be needed and could be constant. When three choices are used we don't really have much freedom where to place the third column/choice.
- [x] Turn `BUTTON_OP_HIGH_NIBBLE_MSK` and `BUTTON_OP_LOW_NIBBLE_MSK` into macros such that `BUTTON_OP_HIGH_NIBBLE_MSK` is `BUTTON_OP_HIGH_NIBBLE(X) ( (X & 0xF0) >> 4 )`
- [x] Set the middle button as the default choice when there are three choices. Else the left most button when there are two choices. This requires changing the parameter type for `default_first` from `bool` to `uint8_t` in `lcd_show_multiscreen_message_with_choices_and_wait_P`.
- [x] Create an `enum` for the button choices to make the code more readable. `enum { LEFT_BUTTON_CHOICE = 0, MIDDLE_BUTTON_CHOICE = 1, RIGHT_BUTTON_CHOICE = 2 };`
- [x] Change name of variable `yes` in `lcd_show_multiscreen_message_with_choices_and_wait_P` to something more descriptive. (it no longer represents only yes or no)

----

List of changes:

----

Change in memory consumption:

----