### PR TITLE
PFW-1318 and PFW-1323

### DIFF
--- a/Firmware/lcd.h
+++ b/Firmware/lcd.h
@@ -167,14 +167,14 @@ extern void lcd_buttons_update(void);
 //Custom characters defined in the first 8 characters of the LCD
 #define LCD_STR_BEDTEMP      "\x00"
 #define LCD_STR_DEGREE       "\x01"
-#define LCD_STR_ARROW_2_DOWN "\x01"
 #define LCD_STR_THERMOMETER  "\x02"
-#define LCD_STR_CONFIRM      "\x02"
 #define LCD_STR_UPLEVEL      "\x03"
 #define LCD_STR_REFRESH      "\x04"
 #define LCD_STR_FOLDER       "\x05"
 #define LCD_STR_FEEDRATE     "\x06"
+#define LCD_STR_ARROW_2_DOWN "\x06"
 #define LCD_STR_CLOCK        "\x07"
+#define LCD_STR_CONFIRM      "\x07"
 #define LCD_STR_ARROW_RIGHT  "\x7E" //from the default character set
 #define LCD_STR_SOLID_BLOCK  "\xFF"  //from the default character set
 

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -91,6 +91,7 @@ MMU2::MMU2()
     , mmu_print_saved(false)
     , loadFilamentStarted(false)
     , loadingToNozzle(false)
+    , is_mmu_error_monitor_active(false)
 {
 }
 
@@ -166,7 +167,14 @@ void MMU2::mmu_loop() {
     avoidRecursion = true;
 
     logicStepLastStatus = LogicStep(); // it looks like the mmu_loop doesn't need to be a blocking call
-    
+
+    if (is_mmu_error_monitor_active)
+    {
+        // Call this every iteration to keep the knob rotation responsive
+        // This includes when mmu_loop is called within manage_response
+        ReportErrorHook((uint16_t)lastErrorCode);
+    }
+
     avoidRecursion = false;
 }
 
@@ -607,7 +615,7 @@ void MMU2::ReportError(ErrorCode ec) {
     // - report only changes of states (we can miss an error message)
     // - may be some combination of MMUAvailable + UseMMU flags and decide based on their state
     // Right now the filtering of MMU_NOT_RESPONDING is done in ReportErrorHook() as it is not a problem if mmu2.cpp
-    ReportErrorHook((CommandInProgress)logic.CommandInProgress(), (uint16_t)ec);
+    ReportErrorHook((uint16_t)ec);
 
     if( ec != lastErrorCode ){ // deduplicate: only report changes in error codes into the log
         lastErrorCode = ec;

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -82,7 +82,8 @@ void WaitForHotendTargetTempBeep(){
 MMU2 mmu2;
 
 MMU2::MMU2()
-    : logic(&mmu2Serial)
+    : is_mmu_error_monitor_active(false)
+    , logic(&mmu2Serial)
     , extruder(MMU2_NO_TOOL)
     , resume_position()
     , resume_hotend_temp(0)
@@ -91,7 +92,6 @@ MMU2::MMU2()
     , mmu_print_saved(false)
     , loadFilamentStarted(false)
     , loadingToNozzle(false)
-    , is_mmu_error_monitor_active(false)
 {
 }
 

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -119,7 +119,10 @@ public:
 
     /// @returns current state of FINDA (true=filament present, false=filament not present)
     inline bool FindaDetectsFilament()const { return logic.FindaPressed(); }
-    
+
+    /// @returns Current error code
+    inline ErrorCode MMUCurrentErrorCode() const { return logic.Error(); }
+
     /// @returns the version of the connected MMU FW.
     /// In the future we'll return the trully detected FW version
     Version GetMMUFWVersion()const {

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -130,6 +130,9 @@ public:
         }
     }
 
+    // Helper variable to monitor knob in MMU error screen in blocking functions e.g. manage_response
+    bool is_mmu_error_monitor_active;
+
     /// Method to read-only mmu_print_saved
     bool MMU_PRINT_SAVED() const { return mmu_print_saved; }
 

--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -274,7 +274,7 @@ static const char btnRestartMMU[] PROGMEM_I1 = ISTR("RstMMU");
 static const char btnUnload[] PROGMEM_I1 = ISTR("Unload");
 static const char btnStop[] PROGMEM_I1 = ISTR("Stop");
 static const char btnDisableMMU[] PROGMEM_I1 = ISTR("Disable");
-static const char btnMore[] PROGMEM_I1 = ISTR("More\x01");
+static const char btnMore[] PROGMEM_I1 = ISTR("More\x06");
 
 // Used to parse the buttons from Btns().
 static const char * const btnOperation[] PROGMEM = {

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -64,7 +64,6 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
     bool two_choices = false;
 
     // Read and determine what operations should be shown on the menu
-    // Note: uint16_t is used here to avoid compiler warning. uint8_t is only half the size of void*
     const uint8_t button_operation   = PrusaErrorButtons(ei);
     const uint8_t button_op_right = BUTTON_OP_RIGHT(button_operation);
     const uint8_t button_op_middle  = BUTTON_OP_MIDDLE(button_operation);
@@ -106,7 +105,6 @@ static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     static int8_t enc_dif = 0;
 
     // Read and determine what operations should be shown on the menu
-    // Note: uint16_t is used here to avoid compiler warning. uint8_t is only half the size of void*
     const uint8_t button_operation   = PrusaErrorButtons(ei);
     const uint8_t button_op_right = BUTTON_OP_RIGHT(button_operation);
     const uint8_t button_op_middle  = BUTTON_OP_MIDDLE(button_operation);

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -1,8 +1,10 @@
+#include "mmu2.h"
 #include "mmu2_reporting.h"
 #include "mmu2_error_converter.h"
 #include "mmu2/error_codes.h"
 #include "mmu2/buttons.h"
 #include "ultralcd.h"
+#include "Filament_sensor.h"
 #include "language.h"
 
 namespace MMU2 {
@@ -19,13 +21,39 @@ void EndReport(CommandInProgress cip, uint16_t ec) {
     custom_message_type = CustomMsg::Status;
 }
 
+// Callback which is called while the printer is
+// waiting for the user to click a button option
+static void ReportErrorHook_cb(void)
+{
+    //TODO: MK3S needs to request an update for the FINDA value
+    //      if we want it to be updated live on the menu screen
+    lcd_set_cursor(3, 2);
+    lcd_printf_P(PSTR("%d"), mmu2.FindaDetectsFilament());
+
+    lcd_set_cursor(8, 2);
+    lcd_printf_P(PSTR("%d"), fsensor.getFilamentPresent());
+
+    lcd_set_cursor(11, 2);
+    lcd_print("?>?"); // This is temporary until below TODO is resolved
+
+    // TODO, see lcdui_print_extruder(void)
+    //if (MMU2::mmu2.get_current_tool() == MMU2::FILAMENT_UNKNOWN)
+    //    lcd_printf_P(_N(" ?>%u"), tmp_extruder + 1);
+    //else
+    //    lcd_printf_P(_N(" %u>%u"), MMU2::mmu2.get_current_tool() + 1, tmp_extruder + 1);
+
+    // Print active extruder temperature
+    lcd_set_cursor(16, 2);
+    lcd_printf_P(PSTR("%d"), (int)(degHotend(0) + 0.5));
+}
+
 void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
     //! Show an error screen
     //! When an MMU error occurs, the LCD content will look like this:
     //! |01234567890123456789|
     //! |MMU FW update needed|     <- title/header of the error: max 20 characters
     //! |prusa3d.com/ERR04504|     <- URL 20 characters
-    //! |                    |     <- empty line
+    //! |FI:1 FS:1  5>3 t201°|     <- status line, t is thermometer symbol
     //! |>Retry  >Done >MoreW|     <- buttons
     const uint8_t ei = PrusaErrorCodeIndex(ec);
     uint8_t choice_selected = 0;
@@ -51,6 +79,10 @@ back_to_choices:
     // Print title and header
     lcd_printf_P(PSTR("%.20S\nprusa3d.com/ERR04%hu"), _T(PrusaErrorTitle(ei)), PrusaErrorCode(ei) );
 
+    // Render static characters in third line
+    lcd_set_cursor(0, 2);
+    lcd_printf_P(PSTR("FI:  FS:    >  %c   %c"), LCD_STR_THERMOMETER[0], LCD_STR_DEGREE[0]);
+
     // Render the choices and store selection in 'choice_selected'
     choice_selected = lcd_show_multiscreen_message_with_choices_and_wait_P(
         NULL, // NULL, since title screen is not in PROGMEM
@@ -61,7 +93,8 @@ back_to_choices:
         two_choices ? nullptr : _T(PrusaErrorButtonMore()),
         two_choices ? 
             10 // If two choices, allow the first choice to have more characters
-            : 7
+            : 7,
+        ReportErrorHook_cb
     );
 
     if ((two_choices && choice_selected == MIDDLE_BUTTON_CHOICE)      // Two choices and middle button selected

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -76,8 +76,9 @@ static void ReportErrorHookStaticRender(uint16_t ec) {
         two_choices = true;
     }
 
-    lcd_clear();
+    lcd_set_custom_characters_nextpage();
     lcd_update_enable(false);
+    lcd_clear();
 
     // Print title and header
     lcd_printf_P(PSTR("%.20S\nprusa3d.com/ERR04%hu"), _T(PrusaErrorTitle(ei)), PrusaErrorCode(ei) );

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -51,7 +51,7 @@ static void ReportErrorHookDynamicRender(void)
 
 /**
  * @brief Renders any characters that are static on the MMU error screen i.e. they don't change.
- * @param[in] ec Error code
+ * @param[in] ei Error code index
  */
 static void ReportErrorHookStaticRender(uint8_t ei) {
     //! Show an error screen
@@ -92,7 +92,7 @@ static void ReportErrorHookStaticRender(uint8_t ei) {
 
 /**
  * @brief Monitors the LCD button selection without blocking MMU communication
- * @param[in] ec Error code
+ * @param[in] ei Error code index
  * @return 0 if there is no knob click --
  * 1 if user clicked 'More' and firmware should render
  * the error screen when ReportErrorHook is called next --

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -53,7 +53,7 @@ static void ReportErrorHookDynamicRender(void)
  * @brief Renders any characters that are static on the MMU error screen i.e. they don't change.
  * @param[in] ec Error code
  */
-static void ReportErrorHookStaticRender(uint16_t ec) {
+static void ReportErrorHookStaticRender(uint8_t ei) {
     //! Show an error screen
     //! When an MMU error occurs, the LCD content will look like this:
     //! |01234567890123456789|
@@ -61,7 +61,6 @@ static void ReportErrorHookStaticRender(uint16_t ec) {
     //! |prusa3d.com/ERR04504|     <- URL 20 characters
     //! |FI:1 FS:1  5>3 t201°|     <- status line, t is thermometer symbol
     //! |>Retry  >Done >MoreW|     <- buttons
-    const uint8_t ei = PrusaErrorCodeIndex(ec);
     bool two_choices = false;
 
     // Read and determine what operations should be shown on the menu
@@ -101,9 +100,8 @@ static void ReportErrorHookStaticRender(uint16_t ec) {
  * to exit the error screen. The MMU will raise the menu
  * again if the error is not solved.
  */
-static uint8_t ReportErrorHookMonitor(uint16_t ec) {
+static uint8_t ReportErrorHookMonitor(uint8_t ei) {
     uint8_t ret = 0;
-    const uint8_t ei = PrusaErrorCodeIndex(ec);
     bool two_choices = false;
     static int8_t enc_dif = 0;
 
@@ -211,16 +209,18 @@ void ReportErrorHook(uint16_t ec) {
         ReportErrorHookState = ReportErrorHookStates::DISMISS_ERROR_SCREEN;
     }
 
+    const uint8_t ei = PrusaErrorCodeIndex(ec);
+
     switch ((uint8_t)ReportErrorHookState)
     {
     case (uint8_t)ReportErrorHookStates::RENDER_ERROR_SCREEN:
-        ReportErrorHookStaticRender(ec);
+        ReportErrorHookStaticRender(ei);
         ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
         // Fall through
     case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
         mmu2.is_mmu_error_monitor_active = true;
         ReportErrorHookDynamicRender(); // Render dynamic characters
-        switch (ReportErrorHookMonitor(ec))
+        switch (ReportErrorHookMonitor(ei))
         {
             case 0:
                 // No choice selected, return to loop()

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -199,11 +199,9 @@ enum ReportErrorHookStates ReportErrorHookState;
 /**
  * @brief Render MMU error screen on the LCD. This must be non-blocking
  * and allow the MMU and printer to communicate with each other.
- * @param[in] cip Command in progress
  * @param[in] ec Error code
  */
-void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
-    
+void ReportErrorHook(uint16_t ec) {
     switch ((uint8_t)ReportErrorHookState)
     {
     case (uint8_t)ReportErrorHookStates::RENDER_ERROR_SCREEN:
@@ -211,6 +209,7 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
         ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
         // Fall through
     case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
+        mmu2.is_mmu_error_monitor_active = true;
         ReportErrorHookDynamicRender(); // Render dynamic characters
         switch (ReportErrorHookMonitor(ec))
         {
@@ -227,6 +226,7 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
                 lcd_update_enable(true);
                 lcd_return_to_status();
                 // Reset the state in case a new error is reported
+                mmu2.is_mmu_error_monitor_active = false;
                 ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
                 break;
             default:

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -6,6 +6,7 @@
 #include "ultralcd.h"
 #include "Filament_sensor.h"
 #include "language.h"
+#include "temperature.h"
 
 namespace MMU2 {
 

--- a/Firmware/mmu2_reporting.cpp
+++ b/Firmware/mmu2_reporting.cpp
@@ -7,6 +7,7 @@
 #include "Filament_sensor.h"
 #include "language.h"
 #include "temperature.h"
+#include "sound.h"
 
 namespace MMU2 {
 
@@ -22,12 +23,8 @@ void EndReport(CommandInProgress cip, uint16_t ec) {
     custom_message_type = CustomMsg::Status;
 }
 
-// Callback which is called while the printer is
-// waiting for the user to click a button option
-static void ReportErrorHook_cb(void)
+static void ReportErrorHookDynamicRender(void)
 {
-    //TODO: MK3S needs to request an update for the FINDA value
-    //      if we want it to be updated live on the menu screen
     lcd_set_cursor(3, 2);
     lcd_printf_P(PSTR("%d"), mmu2.FindaDetectsFilament());
 
@@ -48,7 +45,7 @@ static void ReportErrorHook_cb(void)
     lcd_printf_P(PSTR("%d"), (int)(degHotend(0) + 0.5));
 }
 
-void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
+static void ReportErrorHookStaticRender(uint16_t ec) {
     //! Show an error screen
     //! When an MMU error occurs, the LCD content will look like this:
     //! |01234567890123456789|
@@ -57,7 +54,6 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
     //! |FI:1 FS:1  5>3 t201°|     <- status line, t is thermometer symbol
     //! |>Retry  >Done >MoreW|     <- buttons
     const uint8_t ei = PrusaErrorCodeIndex(ec);
-    uint8_t choice_selected = 0;
     bool two_choices = false;
 
     // Read and determine what operations should be shown on the menu
@@ -72,7 +68,6 @@ void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
         two_choices = true;
     }
 
-back_to_choices:
     lcd_clear();
     lcd_update_enable(false);
 
@@ -83,36 +78,148 @@ back_to_choices:
     lcd_set_cursor(0, 2);
     lcd_printf_P(PSTR("FI:  FS:    >  %c   %c"), LCD_STR_THERMOMETER[0], LCD_STR_DEGREE[0]);
 
-    // Render the choices and store selection in 'choice_selected'
-    choice_selected = lcd_show_multiscreen_message_with_choices_and_wait_P(
-        NULL, // NULL, since title screen is not in PROGMEM
-        false,
-        two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, // beware - LEFT button on the LCD matches the MIDDLE button on the MMU!
-        _T(PrusaErrorButtonTitle(button_op_middle)),
-        _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)),
-        two_choices ? nullptr : _T(PrusaErrorButtonMore()),
-        two_choices ? 
-            10 // If two choices, allow the first choice to have more characters
-            : 7,
-        ReportErrorHook_cb
-    );
+    // Render the choices
+    lcd_show_choices_prompt_P(two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE, _T(PrusaErrorButtonTitle(button_op_middle)), _T(two_choices ? PrusaErrorButtonMore() : PrusaErrorButtonTitle(button_op_right)), two_choices ? 10 : 7, two_choices ? nullptr : _T(PrusaErrorButtonMore()));
+}
+
+static uint8_t ReportErrorHookMonitor(uint16_t ec) {
+    const uint8_t ei = PrusaErrorCodeIndex(ec);
+    bool two_choices = false;
+    static int8_t enc_dif = 0;
+
+    // Read and determine what operations should be shown on the menu
+    // Note: uint16_t is used here to avoid compiler warning. uint8_t is only half the size of void*
+    const uint8_t button_operation   = PrusaErrorButtons(ei);
+    const uint8_t button_op_right = BUTTON_OP_RIGHT(button_operation);
+    const uint8_t button_op_middle  = BUTTON_OP_MIDDLE(button_operation);
+
+    // Check if the menu should have three or two choices
+    if (button_op_right == (uint8_t)ButtonOperations::NoOperation){
+        // Two operations not specified, the error menu should only show two choices
+        two_choices = true;
+    }
+
+    static int8_t current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+    static int8_t choice_selected = -1;
+
+    // Check if knob was rotated
+    if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
+        if (two_choices == false) { // third_choice is not nullptr, safe to dereference
+            if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+                // Rotating knob counter clockwise
+                current_selection--;
+            } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_RIGHT_BUTTON_CHOICE) {
+                // Rotating knob clockwise
+                current_selection++;
+            }
+        } else {
+            if (enc_dif > lcd_encoder_diff && current_selection != LCD_LEFT_BUTTON_CHOICE) {
+                // Rotating knob counter clockwise
+                current_selection = LCD_LEFT_BUTTON_CHOICE;
+            } else if (enc_dif < lcd_encoder_diff && current_selection != LCD_MIDDLE_BUTTON_CHOICE) {
+                // Rotating knob clockwise
+                current_selection = LCD_MIDDLE_BUTTON_CHOICE;
+            }
+        }
+
+        // Update '>' render only
+        lcd_set_cursor(0, 3);
+        lcd_print(current_selection == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');
+        if (two_choices == false)
+        {
+            lcd_set_cursor(7, 3);
+            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
+            lcd_set_cursor(13, 3);
+            lcd_print(current_selection == LCD_RIGHT_BUTTON_CHOICE ? '>': ' ');
+        } else {
+            lcd_set_cursor(10, 3);
+            lcd_print(current_selection == LCD_MIDDLE_BUTTON_CHOICE ? '>': ' ');
+        }
+        // Consume rotation event and make feedback sound
+        enc_dif = lcd_encoder_diff;
+        Sound_MakeSound(e_SOUND_TYPE_EncoderMove);
+    }
+
+    // Check if knob was clicked and consume the event
+    if (lcd_clicked()) {
+        Sound_MakeSound(e_SOUND_TYPE_ButtonEcho);
+        choice_selected = current_selection;
+
+        // Reset current_selection
+        current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+    }
+
+    // return to loop()
+    if (choice_selected == -1) { // No selection, continue monitoring
+        return 0;
+    }
 
     if ((two_choices && choice_selected == LCD_MIDDLE_BUTTON_CHOICE)      // Two choices and middle button selected
         || (!two_choices && choice_selected == LCD_RIGHT_BUTTON_CHOICE)) // Three choices and right most button selected
     {
         // 'More' show error description
         lcd_show_fullscreen_message_and_wait_P(_T(PrusaErrorDesc(ei)));
+        current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+        choice_selected = -1;
+        return 1;
 
         // Return back to the choice menu
-        goto back_to_choices;
     } else if(choice_selected == LCD_MIDDLE_BUTTON_CHOICE) {
         SetButtonResponse((ButtonOperations)button_op_right);
+        current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+        choice_selected = -1;
+        return 2;
     } else {
         SetButtonResponse((ButtonOperations)button_op_middle);
+        current_selection = two_choices ? LCD_LEFT_BUTTON_CHOICE : LCD_MIDDLE_BUTTON_CHOICE;
+        choice_selected = -1;
+        return 2;
     }
-    // if any button/command selected, close the screen
-    lcd_update_enable(true);
-    lcd_return_to_status();
+}
+
+enum class ReportErrorHookStates : uint8_t {
+    RENDER_ERROR_SCREEN = 0,
+    MONITOR_SELECTION = 1,
+};
+
+enum ReportErrorHookStates ReportErrorHookState;
+
+void ReportErrorHook(CommandInProgress cip, uint16_t ec) {
+    
+    switch ((uint8_t)ReportErrorHookState)
+    {
+    case (uint8_t)ReportErrorHookStates::RENDER_ERROR_SCREEN:
+        // START
+        ReportErrorHookStaticRender(ec);
+        ReportErrorHookState = ReportErrorHookStates::MONITOR_SELECTION;
+        // Fall through
+    case (uint8_t)ReportErrorHookStates::MONITOR_SELECTION:
+        ReportErrorHookDynamicRender(); // Render dynamic characters
+        switch (ReportErrorHookMonitor(ec))
+        {
+            case 0:
+                // No choice selected, return to loop()
+                break;
+            case 1:
+                // More button selected, change state
+                ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
+                break;
+            case 2:
+                // Exit error screen and enable lcd updates
+                lcd_set_custom_characters();
+                lcd_update_enable(true);
+                lcd_return_to_status();
+                // Reset the state in case a new error is reported
+                ReportErrorHookState = ReportErrorHookStates::RENDER_ERROR_SCREEN;
+                break;
+            default:
+                break;
+        }
+        return; // Always return to loop() to let MMU trigger a call to ReportErrorHook again
+        break;
+    default:
+        break;
+    }
 }
 
 void ReportProgressHook(CommandInProgress cip, uint16_t ec) {

--- a/Firmware/mmu2_reporting.h
+++ b/Firmware/mmu2_reporting.h
@@ -23,7 +23,7 @@ void BeginReport(CommandInProgress cip, uint16_t ec);
 void EndReport(CommandInProgress cip, uint16_t ec);
 
 /// Called when the MMU sends operation error (even repeatedly)
-void ReportErrorHook(CommandInProgress cip, uint16_t ec);
+void ReportErrorHook(uint16_t ec);
 
 /// Called when the MMU sends operation progress update
 void ReportProgressHook(CommandInProgress cip, uint16_t ec);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -97,7 +97,7 @@ static const char separator[] PROGMEM = "--------------------";
 
 /** forward declarations **/
 
-static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg, uint8_t &nlines);
+static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg);
 // void copy_and_scalePID_i();
 // void copy_and_scalePID_d();
 

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3214,7 +3214,6 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 //! @param second_choice text caption of second possible choice. Must be in PROGMEM
 //! @param third_choice text caption of second possible choice. Must be in PROGMEM. When not set to nullptr first_choice and second_choice may not be more than 5 characters long.
 //! @param second_col column on LCD where second_choice starts
-//! @param multiscreen_cb an optional call back that will be called periodically when the printer is paused for user
 //! @retval 0 first choice selected by user
 //! @retval 1 first choice selected by user
 //! @retval 2 third choice selected by user
@@ -3222,7 +3221,7 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
     const char *const msg, bool allow_timeouting, uint8_t default_selection,
     const char *const first_choice, const char *const second_choice, const char *const third_choice,
-    uint8_t second_col, bool (*lcdHook)()
+    uint8_t second_col
 ) {
     const char *msg_next = msg ? lcd_display_message_fullscreen_P(msg) : NULL;
     bool multi_screen = msg_next != NULL;
@@ -3243,11 +3242,6 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
             delay_keep_alive(50);
             if (allow_timeouting && _millis() - previous_millis_cmd > LCD_TIMEOUT_TO_STATUS) {
                 return -1;
-            }
-            if (lcdHook){
-                if( lcdHook()) {
-                    return -1;
-                }
             }
             manage_heater();
             manage_inactivity(true);

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3186,7 +3186,7 @@ int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allo
 //! @param second_choice text caption of second possible choice
 //! @param second_col column on LCD where second choice is rendered. If third choice is set, this value is hardcoded to 7
 //! @param third_choice text caption of third, optional, choice.
-void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const char *second_choice, uint8_t second_col, const char *third_choice = nullptr)
+void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const char *second_choice, uint8_t second_col, const char *third_choice)
 {
     lcd_set_cursor(0, 3);
     lcd_print(selected == LCD_LEFT_BUTTON_CHOICE ? '>': ' ');

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -3216,12 +3216,14 @@ void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const
 //! @param second_choice text caption of second possible choice. Must be in PROGMEM
 //! @param third_choice text caption of second possible choice. Must be in PROGMEM. When not set to nullptr first_choice and second_choice may not be more than 5 characters long.
 //! @param second_col column on LCD where second_choice starts
+//! @param multiscreen_cb an optional call back that will be called periodically when the printer is paused for user
 //! @retval 0 first choice selected by user
 //! @retval 1 first choice selected by user
 //! @retval 2 third choice selected by user
 //! @retval -1 screen timed out (only possible if allow_timeouting is true)
 int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char * const msg, bool allow_timeouting, uint8_t default_selection,
-       const char * const first_choice, const char * const second_choice, const char * const third_choice, uint8_t second_col)
+       const char * const first_choice, const char * const second_choice, const char * const third_choice, uint8_t second_col,
+	   void (*multiscreen_cb)(void))
 {
 	const char *msg_next = msg ? lcd_display_message_fullscreen_P(msg) : NULL;
 	bool multi_screen = msg_next != NULL;
@@ -3246,6 +3248,12 @@ int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char * const m
 			}
 			manage_heater();
 			manage_inactivity(true);
+
+			if (multiscreen_cb)
+			{
+				multiscreen_cb();
+			}
+			
 
 			if (abs(enc_dif - lcd_encoder_diff) >= ENCODER_PULSES_PER_STEP) {
 				if (msg_next == NULL) {

--- a/Firmware/ultralcd.cpp
+++ b/Firmware/ultralcd.cpp
@@ -2310,9 +2310,8 @@ void lcd_load_filament_color_check()
 #ifdef FILAMENT_SENSOR
 static void lcd_menu_AutoLoadFilament()
 {
-     uint8_t nlines;
-     lcd_display_message_fullscreen_nonBlocking_P(_i("Autoloading filament is active, just press the knob and insert filament..."),nlines);////MSG_AUTOLOADING_ENABLED c=20 r=4
-     menu_back_if_clicked();
+    lcd_display_message_fullscreen_nonBlocking_P(_i("Autoloading filament is active, just press the knob and insert filament..."));////MSG_AUTOLOADING_ENABLED c=20 r=4
+    menu_back_if_clicked();
 }
 #endif //FILAMENT_SENSOR
 
@@ -3034,10 +3033,9 @@ static inline bool pgm_is_interpunction(const char *c_addr)
  *
  * This function is non-blocking
  * @param msg message to be displayed from PROGMEM
- * @param nlines
  * @return rest of the text (to be displayed on next page)
  */
-static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg, uint8_t &nlines)
+static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg)
 {
     lcd_set_cursor(0, 0);
     const char *msgend = msg;
@@ -3086,22 +3084,15 @@ static const char* lcd_display_message_fullscreen_nonBlocking_P(const char *msg,
         lcd_print(LCD_STR_ARROW_2_DOWN[0]);
     }
 
-    nlines = row;
     return multi_screen ? msgend : NULL;
 }
 
-const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines)
+const char* lcd_display_message_fullscreen_P(const char *msg)
 {
     // Disable update of the screen by the usual lcd_update(0) routine.
     lcd_update_enable(false);
     lcd_clear();
-//	uint8_t nlines;
-    return lcd_display_message_fullscreen_nonBlocking_P(msg, nlines);
-}
-const char* lcd_display_message_fullscreen_P(const char *msg) 
-{
-  uint8_t nlines;
-  return lcd_display_message_fullscreen_P(msg, nlines);
+    return lcd_display_message_fullscreen_nonBlocking_P(msg);
 }
 
 

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -75,6 +75,7 @@ extern const char* lcd_display_message_fullscreen_P(const char *msg);
 extern void lcd_return_to_status();
 extern void lcd_wait_for_click();
 extern bool lcd_wait_for_click_delay(uint16_t nDelay);
+void lcd_show_choices_prompt_P(uint8_t selected, const char *first_choice, const char *second_choice, uint8_t second_col, const char *third_choice = nullptr);
 extern void lcd_show_fullscreen_message_and_wait_P(const char *msg);
 // 1: no, 0: yes, -1: timeouted
 extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -82,7 +82,8 @@ extern int8_t lcd_show_yes_no_and_wait(bool allow_timeouting = true, uint8_t def
 // 1: no, 0: yes, -1: timeouted
 extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(const char * const msg, bool allow_timeouting, uint8_t default_selection,
-        const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr, uint8_t second_col = 7);
+        const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr, uint8_t second_col = 7,
+        void (*multiscreen_cb)(void) = nullptr);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = MIDDLE_BUTTON_CHOICE);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -71,7 +71,6 @@ enum ButtonChoice
     RIGHT_BUTTON_CHOICE = 2,
 };
 
-extern const char* lcd_display_message_fullscreen_P(const char *msg, uint8_t &nlines);
 extern const char* lcd_display_message_fullscreen_P(const char *msg);
 
 extern void lcd_return_to_status();

--- a/Firmware/ultralcd.h
+++ b/Firmware/ultralcd.h
@@ -84,7 +84,7 @@ extern int8_t lcd_show_fullscreen_message_yes_no_and_wait_P(const char *msg, boo
 extern int8_t lcd_show_multiscreen_message_with_choices_and_wait_P(
     const char * const msg, bool allow_timeouting, uint8_t default_selection,
     const char * const first_choice, const char * const second_choice, const char * const third_choice = nullptr,
-    uint8_t second_col = 7, bool (*lcdHook)() = nullptr);
+    uint8_t second_col = 7);
 extern int8_t lcd_show_multiscreen_message_yes_no_and_wait_P(const char *msg, bool allow_timeouting = true, uint8_t default_selection = LCD_MIDDLE_BUTTON_CHOICE);
 // Ask the user to move the Z axis up to the end stoppers and let
 // the user confirm that it has been done.


### PR DESCRIPTION
JIRA tickets: 
* https://dev.prusa3d.com/browse/PFW-1318
* https://dev.prusa3d.com/browse/PFW-1323

Change in memory footprint:
BEFORE
```
Sketch uses 225058 bytes (88%) of program storage space. Maximum is 253952 bytes.
Global variables use 5785 bytes of dynamic memory.
```

AFTER:
```
Sketch uses 225392 bytes (88%) of program storage space. Maximum is 253952 bytes.
Global variables use 5801 bytes of dynamic memory.
```

Flash: +334 bytes
SRAM: +16 bytes
