### PR TITLE
Fix sPrinterName not set when using MMU

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -8294,7 +8294,10 @@ Sigma_Exit:
                     break;
                case ClPrintChecking::_Smodel:     // ~ .3
                     if(code_seen('P'))
-                         printer_smodel_check(strchr_pointer);
+                    {
+                        fSetMmuMode(MMU2::mmu2.Enabled());
+                        printer_smodel_check(strchr_pointer);
+                    }
                     else if(code_seen('Q'))
                          SERIAL_PROTOCOLLNRPGM(sPrinterName);
                     break;


### PR DESCRIPTION
The MMU gcode I'm using doesn't call M862.2, but it does call M862.3

I'm using default settings in PrusaSlicer.

```
;TYPE:Custom
M862.3 P "MK3SMMU2S" ; printer model check
M862.1 P0.4 ; nozzle diameter check
```

PFW-1338