### PR TITLE
PFW-1334 Move E-motor on FSENSOR error retry

### DIFF
--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -36,6 +36,7 @@ static constexpr float MMU2_LOAD_TO_NOZZLE_LENGTH = 87.0F + 5.0F;
 static constexpr float MMU2_TOOL_CHANGE_LOAD_LENGTH = 30.0F;
 
 static constexpr float MMU2_LOAD_TO_NOZZLE_FEED_RATE = 20.0F;
+static constexpr float MMU2_UNLOAD_TO_FINDA_FEED_RATE = 120.0F;
 static constexpr uint8_t MMU2_NO_TOOL = 99;
 static constexpr uint32_t MMU_BAUD = 115200;
 
@@ -793,7 +794,8 @@ void MMU2::OnMMUProgressMsg(ProgressCode pc){
             st_synchronize();
             // Now do a fast unload in sync with the MMU
             current_position[E_AXIS] -= 427.0f - 42.85f - 20.0f; // Roughly same distance as MMU plans
-            plan_buffer_line_curposXYZE(120.0f);
+            plan_buffer_line_curposXYZE(MMU2_UNLOAD_TO_FINDA_FEED_RATE);
+            break;
         case ProgressCode::FeedingToBondtech:
             // prepare for the movement of the E-motor
             st_synchronize();

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -847,6 +847,7 @@ void MMU2::OnMMUProgressMsg(ProgressCode pc){
                     unloadFilamentStarted = false;
                 }
             }
+            break;
         case ProgressCode::FeedingToBondtech:
         case ProgressCode::FeedingToFSensor:
             if (loadFilamentStarted) {

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -783,6 +783,12 @@ void MMU2::OnMMUProgressMsg(ProgressCode pc){
         // Act accordingly - one-time handling
         switch (pc) {
         case ProgressCode::UnloadingToFinda:
+            if ((CommandInProgress)logic.CommandInProgress() == CommandInProgress::UnloadFilament)
+            {
+                // If MK3S sent U0 command, then the code below is not relevant.
+                break;
+            }
+
             // This is intended to handle Retry option on MMU error screen
             // MMU sends P3 progress code during Query, and if filament is stuck
             // in the gears, the MK3S needs to move e-axis as well.

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -703,6 +703,19 @@ void MMU2::ReportError(ErrorCode ec) {
     // - report only changes of states (we can miss an error message)
     // - may be some combination of MMUAvailable + UseMMU flags and decide based on their state
     // Right now the filtering of MMU_NOT_RESPONDING is done in ReportErrorHook() as it is not a problem if mmu2.cpp
+
+    // Depending on the Progress code, we may want to do some action when an error occurs
+    switch (logic.Progress())
+    {
+    case ProgressCode::FeedingToBondtech:
+    case ProgressCode::FeedingToFSensor:
+        // FSENSOR error during load. Make sure E-motor stops moving.
+        loadFilamentStarted = false;
+        break;
+    default:
+        break;
+    }
+
     ReportErrorHook((uint16_t)ec);
 
     if( ec != lastErrorCode ){ // deduplicate: only report changes in error codes into the log

--- a/Firmware/mmu2.cpp
+++ b/Firmware/mmu2.cpp
@@ -93,6 +93,7 @@ MMU2::MMU2()
     , state(xState::Stopped)
     , mmu_print_saved(SavedState::None)
     , loadFilamentStarted(false)
+    , unloadFilamentStarted(false)
     , loadingToNozzle(false)
 {
 }
@@ -737,6 +738,8 @@ void MMU2::ReportError(ErrorCode ec) {
     // Depending on the Progress code, we may want to do some action when an error occurs
     switch (logic.Progress())
     {
+    case ProgressCode::UnloadingToFinda:
+        unloadFilamentStarted = false;
     case ProgressCode::FeedingToBondtech:
     case ProgressCode::FeedingToFSensor:
         // FSENSOR error during load. Make sure E-motor stops moving.
@@ -778,6 +781,19 @@ void MMU2::OnMMUProgressMsg(ProgressCode pc){
 
         // Act accordingly - one-time handling
         switch (pc) {
+        case ProgressCode::UnloadingToFinda:
+            // This is intended to handle Retry option on MMU error screen
+            // MMU sends P3 progress code during Query, and if filament is stuck
+            // in the gears, the MK3S needs to move e-axis as well.
+            st_synchronize();
+            unloadFilamentStarted = true;
+            // Unload slowly while MMU is initalising its axis
+            current_position[E_AXIS] -= 10.0f;
+            plan_buffer_line_curposXYZE(10.0f);
+            st_synchronize();
+            // Now do a fast unload in sync with the MMU
+            current_position[E_AXIS] -= 427.0f - 42.85f - 20.0f; // Roughly same distance as MMU plans
+            plan_buffer_line_curposXYZE(120.0f);
         case ProgressCode::FeedingToBondtech:
             // prepare for the movement of the E-motor
             st_synchronize();
@@ -790,6 +806,19 @@ void MMU2::OnMMUProgressMsg(ProgressCode pc){
     } else {
         // Act accordingly - every status change (even the same state)
         switch (pc) {
+        case ProgressCode::UnloadingToFinda:
+            if (unloadFilamentStarted && !blocks_queued()) { // Only plan a move if there is no move ongoing
+                
+                if (mmu2.FindaDetectsFilament() == 1)
+                { // Keep moving the E-motor until and error happens or FINDA untriggers
+                    current_position[E_AXIS] -= 6.0f;
+                    plan_buffer_line_curposXYZE(60.0f);
+                } else {
+                    // Only stop moving the motor if FINDA is still triggered.
+                    // Even if the FSENSOR is 0, the filament may get stuck in the bondtech gears
+                    unloadFilamentStarted = false;
+                }
+            }
         case ProgressCode::FeedingToBondtech:
         case ProgressCode::FeedingToFSensor:
             if (loadFilamentStarted) {

--- a/Firmware/mmu2.h
+++ b/Firmware/mmu2.h
@@ -240,6 +240,7 @@ private:
 
     uint8_t mmu_print_saved;
     bool loadFilamentStarted;
+    bool unloadFilamentStarted;
     
     friend struct LoadingToNozzleRAII;
     /// true in case we are doing the LoadToNozzle operation - that means the filament shall be loaded all the way down to the nozzle


### PR DESCRIPTION
JIRA ticket: https://dev.prusa3d.com/browse/PFW-1334

When a FSENSOR error happens, the first step for the MK3S should be to stop any loading by stopping the E-motor.

From this point, the buttons should determine what the MK3S does next.