### PR TITLE
PFW-1340 Hide Done button for two errors

### DIFF
--- a/Firmware/mmu2/errors_list.h
+++ b/Firmware/mmu2/errors_list.h
@@ -303,8 +303,8 @@ uint8_t constexpr Btns(ButtonOperations bMiddle, ButtonOperations bRight){
 static const uint8_t errorButtons[] PROGMEM = {
     Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FINDA_DIDNT_TRIGGER
     Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FINDA_DIDNT_GO_OFF
-    Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FSENSOR_DIDNT_TRIGGER
-    Btns(ButtonOperations::Retry, ButtonOperations::Continue),//FSENSOR_DIDNT_GO_OFF
+    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_DIDNT_TRIGGER
+    Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_DIDNT_GO_OFF
 
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//PULLEY_STALLED
     Btns(ButtonOperations::Retry, ButtonOperations::NoOperation),//FSENSOR_TOO_EARLY


### PR DESCRIPTION
Hide Done button for two errors

* `FSENSOR_DIDNT_TRIGGER`
* `FSENSOR_DIDNT_GO_OFF`

The Done button does not Move the E-motor because it
expects the user to have manually resolved the problem

Also if the filament is in the gears, we cannot pull the filament out.
In this case the Retry button is more suited as it will unload the filament.