### PR TITLE
Fix trying to use serial before it's intiialized

### DIFF
--- a/Firmware/Marlin_main.cpp
+++ b/Firmware/Marlin_main.cpp
@@ -1042,10 +1042,6 @@ void setup()
 {
 	timer2_init(); // enables functional millis
 
-	if (eeprom_read_byte((uint8_t *)EEPROM_MMU_ENABLED))
-    {
-        MMU2::mmu2.Start();
-    }
 
 	ultralcd_init();
 
@@ -1060,6 +1056,12 @@ void setup()
 	MYSERIAL.begin(BAUDRATE);
 	fdev_setup_stream(uartout, uart_putchar, NULL, _FDEV_SETUP_WRITE); //setup uart out stream
 	stdout = uartout;
+
+	if (eeprom_read_byte((uint8_t *)EEPROM_MMU_ENABLED))
+    {
+        MMU2::mmu2.Start();
+    }
+
 
 #ifdef XFLASH
     bool xflash_success = xflash_init();


### PR DESCRIPTION
The MMU tries to use the serial during init, don't do that until after the port has been initialized. 