### PR TITLE
Fix protocol error recovery

### DIFF
--- a/Firmware/mmu2_protocol_logic.cpp
+++ b/Firmware/mmu2_protocol_logic.cpp
@@ -6,6 +6,10 @@
 
 namespace MMU2 {
 
+static constexpr uint8_t supportedMmuFWVersionMajor = 2;
+static constexpr uint8_t supportedMmuFWVersionMinor = 0;
+static constexpr uint8_t supportedMmuFWVersionBuild = 19;
+
 StepStatus ProtocolLogicPartBase::ProcessFINDAReqSent(StepStatus finishedRV, State nextState){
     if (auto expmsg = logic->ExpectingMessage(linkLayerTimeout); expmsg != MessageReady)
         return expmsg;
@@ -140,7 +144,7 @@ StepStatus StartSeq::Step() {
                 SendVersion(0);
         } else {
             logic->mmuFwVersionMajor = logic->rsp.paramValue;
-            if (logic->mmuFwVersionMajor != 2) {
+            if (logic->mmuFwVersionMajor != supportedMmuFWVersionMajor) {
                 return VersionMismatch;
             }
             logic->dataTO.Reset(); // got meaningful response from the MMU, stop data layer timeout tracking
@@ -153,7 +157,7 @@ StepStatus StartSeq::Step() {
                 SendVersion(1);
         } else {
             logic->mmuFwVersionMinor = logic->rsp.paramValue;
-            if (logic->mmuFwVersionMinor != 0) {
+            if (logic->mmuFwVersionMinor != supportedMmuFWVersionMinor) {
                 return VersionMismatch;
             }
                 SendVersion(2);
@@ -165,7 +169,7 @@ StepStatus StartSeq::Step() {
                 SendVersion(2);
         } else {
             logic->mmuFwVersionBuild = logic->rsp.paramValue;
-            if (logic->mmuFwVersionBuild < 18) {
+            if (logic->mmuFwVersionBuild < supportedMmuFWVersionBuild) {
                 return VersionMismatch;
             }
             // Start General Interrogation after line up.

--- a/Firmware/mmu2_protocol_logic.h
+++ b/Firmware/mmu2_protocol_logic.h
@@ -77,7 +77,7 @@ protected:
         Ready,
         Wait,
 
-        S0Sent,
+        S0Sent, // beware - due to optimization reasons these SxSent must be kept one after another
         S1Sent,
         S2Sent,
         QuerySent,
@@ -86,7 +86,8 @@ protected:
         FINDAReqSent,
         ButtonSent,
 
-        ContinueFromIdle
+        ContinueFromIdle,
+        RecoveringProtocolError
     };
 
     State state; ///< internal state of the sub-automaton
@@ -108,6 +109,8 @@ protected:
     void SendAndUpdateFilamentSensor();
 
     void SendButton(uint8_t btn);
+
+    void SendVersion(uint8_t stage);
 };
 
 /// Starting sequence of the communication with the MMU.
@@ -117,6 +120,14 @@ protected:
 class StartSeq : public ProtocolLogicPartBase {
 public:
     inline StartSeq(ProtocolLogic *logic)
+        : ProtocolLogicPartBase(logic) {}
+    void Restart() override;
+    StepStatus Step() override;
+};
+
+class DelayedRestart : public ProtocolLogicPartBase {
+public:
+    inline DelayedRestart(ProtocolLogic *logic)
         : ProtocolLogicPartBase(logic) {}
     void Restart() override;
     StepStatus Step() override;
@@ -250,13 +261,12 @@ public:
 #ifndef UNITTEST
 private:
 #endif
-    
-    StepStatus ProcessUARTByte(uint8_t c);
     StepStatus ExpectingMessage(uint32_t timeout);
     void SendMsg(RequestMsg rq);
     void SwitchToIdle();
-    void HandleCommunicationTimeout();
-    StepStatus HandleCommError(const char *msg, StepStatus ss);
+    StepStatus SuppressShortDropOuts(const char *msg, StepStatus ss);
+    StepStatus HandleCommunicationTimeout();
+    StepStatus HandleProtocolError();
     bool Elapsed(uint32_t timeout) const;
     void RecordUARTActivity();
     void RecordReceivedByte(uint8_t c);
@@ -276,6 +286,7 @@ private:
     // individual sub-state machines - may be they can be combined into a union since only one is active at once
     Stopped stopped;
     StartSeq startSeq;
+    DelayedRestart delayedRestart;
     Idle idle;
     Command command;
     ProtocolLogicPartBase *currentState; ///< command currently being processed
@@ -327,6 +338,7 @@ private:
     friend class Command;
     friend class Idle;
     friend class StartSeq;
+    friend class DelayedRestart;
 
     friend class MMU2;
 };


### PR DESCRIPTION
Communication timeout and Protocol Errors are now distinguished.
In case of a Protocol Error, the printer waits for heartBeatTimeout to allow filling up the input UART buffer (we expect the MMU still produces some bytes). 
Once the timeout elapsed, the input UART buffer is cleared and a new Start Sequence is initiated.

To be discussed: the lenght of the timeout before issuing the Start Sequence `S0\n`. May be heartBeatTimeout is unnecessarily long...

PFW-1372